### PR TITLE
Extend delimiters for tag values

### DIFF
--- a/schema/ridl/parser.go
+++ b/schema/ridl/parser.go
@@ -349,7 +349,7 @@ loop:
 		tok := p.cursor()
 
 		switch tok.tt {
-		case tokenWhitespace, tokenNewLine:
+		case tokenWhitespace, tokenNewLine, tokenEOF:
 			break loop
 		}
 

--- a/schema/ridl/parser.go
+++ b/schema/ridl/parser.go
@@ -332,19 +332,29 @@ loop:
 }
 
 func (p *parser) expectMetadataValue() (*token, error) {
-	tokens := []*token{}
+	tok := p.cursor()
 
+	if tok.tt == tokenQuote {
+		var err error
+		tok, err = p.expectStringValue()
+		if err != nil {
+			return nil, err
+		}
+		return tok, nil
+	}
+
+	tokens := []*token{}
 loop:
 	for {
 		tok := p.cursor()
 
 		switch tok.tt {
-		case tokenComma, tokenWord, tokenMinusSign:
-			tokens = append(tokens, tok)
-			p.next()
-		default:
+		case tokenWhitespace, tokenNewLine:
 			break loop
 		}
+
+		tokens = append(tokens, tok)
+		p.next()
 	}
 
 	return composedValue(tokens)

--- a/schema/ridl/ridl_test.go
+++ b/schema/ridl/ridl_test.go
@@ -309,9 +309,7 @@ func TestRIDLMessages(t *testing.T) {
 
         + go.tag.db.2 = default**:**now**()**,use_zero,"// # a comment
         + go.tag.db.3 = "default**:**now**()**,use_zero,// # not a comment" # a comment
-
-  message Simple2 # with a-comment an,d meta fields
-  `
+        + go.tag.db.4 = default**:**now**()**,use_zero`
 		s, err := parseString(input)
 		assert.NoError(t, err)
 
@@ -320,6 +318,7 @@ func TestRIDLMessages(t *testing.T) {
 		assert.Equal(t, "default**:**now**()**,use_zero#000", s.Messages[0].Fields[1].Meta[2]["go.tag.db.1"])
 		assert.Equal(t, `default**:**now**()**,use_zero,"//`, s.Messages[0].Fields[1].Meta[3]["go.tag.db.2"])
 		assert.Equal(t, "default**:**now**()**,use_zero,// # not a comment", s.Messages[0].Fields[1].Meta[4]["go.tag.db.3"])
+		assert.Equal(t, "default**:**now**()**,use_zero", s.Messages[0].Fields[1].Meta[5]["go.tag.db.4"])
 	}
 }
 

--- a/schema/ridl/ridl_test.go
+++ b/schema/ridl/ridl_test.go
@@ -293,6 +293,34 @@ func TestRIDLMessages(t *testing.T) {
 		assert.Equal(t, "[]bool", string(s.Messages[0].Fields[2].Type.String()))
 		assert.Equal(t, "[][][]bool", string(s.Messages[0].Fields[3].Type.String()))
 	}
+
+	{
+		input := `
+    webrpc = v1
+    version = v0.1.1
+  name = hello-webrpc
+
+  message Simple # with a-comment an,d meta fields
+    - ID: uint32
+  - Field2: map<string, string> # one two #t
+      + json = field_2 # a comment
+        + go.tag.db = field_2 # a comment
+    + go.tag.db.1 = default**:**now**()**,use_zero#000 # # # a comment
+
+        + go.tag.db.2 = default**:**now**()**,use_zero,"// # a comment
+        + go.tag.db.3 = "default**:**now**()**,use_zero,// # not a comment" # a comment
+
+  message Simple2 # with a-comment an,d meta fields
+  `
+		s, err := parseString(input)
+		assert.NoError(t, err)
+
+		assert.Equal(t, "map<string,string>", string(s.Messages[0].Fields[1].Type.String()))
+		assert.Equal(t, "field_2", s.Messages[0].Fields[1].Meta[1]["go.tag.db"])
+		assert.Equal(t, "default**:**now**()**,use_zero#000", s.Messages[0].Fields[1].Meta[2]["go.tag.db.1"])
+		assert.Equal(t, `default**:**now**()**,use_zero,"//`, s.Messages[0].Fields[1].Meta[3]["go.tag.db.2"])
+		assert.Equal(t, "default**:**now**()**,use_zero,// # not a comment", s.Messages[0].Fields[1].Meta[4]["go.tag.db.3"])
+	}
 }
 
 func TestRIDLService(t *testing.T) {


### PR DESCRIPTION
> I think tab could work to delimit, but that is pretty much it, as some people might want space or other characters in their value, prob not tab or newline tho

@pkieltyka accepting spaces and handling cases like:

```
+ tag = this a tag value with # spaces # and hash# sign # and this is a comment
```

would be problematic from the parser's point of view (because identifying a comment would depend on the context and we'll have to ask things like _is this the last `#` preceded by `[whitespace]` on this line?_)

What we can do to solve this problem is to look for [whitespace] or [newline] to mark the end of a token, and also add support for quoted values that may include [whitespace]. See below:

```
+ json = field_2 # a comment
+ go.tag.db = field_2 # a comment
+ go.tag.db.1 = default**:**now**()**,use_zero#000 # # # a comment with two hashes
+ go.tag.db.2 = default**:**now**()**,use_zero,"// # a comment
+ go.tag.db.3 = "default**:**now**()**,use_zero,// # this is not a comment" # this is a comment
+ go.tag.db.4 = default**:**now**()**,use_zero
```

What do you think?

Closes https://github.com/webrpc/webrpc/issues/60
