### PR TITLE
Add sublime syntax highlighter for tmpl files 

### DIFF
--- a/GoTemplate.sublime-syntax
+++ b/GoTemplate.sublime-syntax
@@ -1,0 +1,60 @@
+%YAML 1.2
+---
+name: 'Go Template'
+file_extensions:
+  - go.tmpl
+scope: source.go
+contexts:
+  main:
+    - match: ''
+      push: Packages/Go/Go.sublime-syntax
+      with_prototype:
+        - match: '{{'
+          scope: comment.line.gotemplate
+          captures:
+            0: punctuation.section.embedded.begin.gotemplate
+          push:
+            - expr
+
+  expr:
+    - match: ":="
+      scope: keyword.operator.initialize.gotemplate
+    - match: \|
+      scope: keyword.operator.pipe.gotemplate
+    - match: \b(if|else|range|template|with|end|nil|define)\b
+      scope: keyword.control.gotemplate
+    - match: \b(and|call|html|index|js|len|not|or|print|printf|println|urlquery|eq|ne|lt|le|gt|ge)\b
+      scope: support.function.builtin.gotemplate
+    - match: '[\.\$][\w]*'
+      scope: variable.other.gotemplate
+    - match: /\*
+      push:
+        - meta_scope: comment.block.gotemplate
+        - match: \*/
+          pop: true
+    - match: '"'
+      captures:
+        0: punctuation.definition.string.begin.gotemplate
+      push:
+        - meta_scope: string.quoted.double.gotemplate
+        - match: '"'
+          captures:
+            0: punctuation.definition.string.end.gotemplate
+          pop: true
+        - include: string_placeholder
+        - include: string_escaped_char
+    - match: "`"
+      captures:
+        0: punctuation.definition.string.begin.gotemplate
+      push:
+        - meta_scope: string.quoted.raw.gotemplate
+        - match: "`"
+          captures:
+            0: punctuation.definition.string.end.gotemplate
+          pop: true
+        - include: string_placeholder
+    - match: '}}'
+      scope: comment.line.gotemplate
+      captures:
+        0: punctuation.section.embedded.end.gotemplate
+      pop: true


### PR DESCRIPTION
It would be ideal for something like this to live externally, maybe a maintainer can direct me to a good place to put this? I'll add README info if/when a placement is determined. It makes working with the tmpl files a bit nicer. 

before: 
<img width="927" alt="image" src="https://user-images.githubusercontent.com/13735595/83571288-7f6cc900-a4f5-11ea-900a-59b800404b18.png">
after: 
<img width="951" alt="image" src="https://user-images.githubusercontent.com/13735595/83571275-78de5180-a4f5-11ea-9b74-cc1df0bfd2c7.png">