### PR TITLE
Fetch wrapper

### DIFF
--- a/_examples/hello-webrpc-ts/webapp/package.json
+++ b/_examples/hello-webrpc-ts/webapp/package.json
@@ -6,9 +6,6 @@
   "scripts": {
     "start": "webpack-dev-server --mode development --progress --color --config webpack.config.js"
   },
-  "dependencies": {
-    "whatwg-fetch": "3.0.0"
-  },
   "devDependencies": {
     "fork-ts-checker-webpack-plugin": "0.5.2",
     "html-webpack-plugin": "3.2.0",

--- a/_examples/hello-webrpc-ts/webapp/src/index.ts
+++ b/_examples/hello-webrpc-ts/webapp/src/index.ts
@@ -4,10 +4,9 @@
 // see the `hello-api.ridl` schema where the API is defined
 // and the client.gen.ts file is code-generated which we use below..
 //
-import { fetch as polyfetch } from 'whatwg-fetch'
 import * as client from './client.gen'
 
-const api = new client.ExampleService('http://127.0.01:4242', polyfetch)
+const api = new client.ExampleService('http://127.0.01:4242', fetch)
 
 async function main() {
 

--- a/_examples/hello-webrpc/webapp/index.html
+++ b/_examples/hello-webrpc/webapp/index.html
@@ -16,8 +16,7 @@
 </div>
 
 <script>
-  const svcFetch = window.fetch.bind(window)
-  let svc = new ExampleService('http://127.0.0.1:4242', svcFetch)
+  let svc = new ExampleService('http://127.0.0.1:4242', fetch)
 
   // Expecting "true"
   console.log('[A] webrpc -- calling Ping() rpc method (expecting true):')

--- a/gen/javascript/templates/client.js.tmpl
+++ b/gen/javascript/templates/client.js.tmpl
@@ -8,7 +8,7 @@
   constructor(hostname, fetch) {
     this.path = '/rpc/{{.Name}}/'
     this.hostname = hostname
-    this.fetch = (input: RequestInfo, init?: RequestInit) => fetch(input, init)
+    this.fetch = (input, init) => fetch(input, init)
   }
 
   url(name) {

--- a/gen/javascript/templates/client.js.tmpl
+++ b/gen/javascript/templates/client.js.tmpl
@@ -8,7 +8,7 @@
   constructor(hostname, fetch) {
     this.path = '/rpc/{{.Name}}/'
     this.hostname = hostname
-    this.fetch = fetch
+    this.fetch = (input: RequestInfo, init?: RequestInit) => fetch(input, init)
   }
 
   url(name) {

--- a/gen/typescript/templates/client.ts.tmpl
+++ b/gen/typescript/templates/client.ts.tmpl
@@ -12,7 +12,7 @@ export class {{.Name}} implements {{.Name | serviceInterfaceName}} {
 
   constructor(hostname: string, fetch: Fetch) {
     this.hostname = hostname
-    this.fetch = fetch
+    this.fetch = (input: RequestInfo, init?: RequestInit) => fetch(input, init)
   }
 
   private url(name: string): string {


### PR DESCRIPTION
Adds a wrapper function to fetch, this allows you pass fetch without binding it to the window first.
Especially useful if you use WebRPC with the Fetch API in the browser and only polyfill in environments that do not have a native fetch. [(This is what SvelteKit does)](https://github.com/sveltejs/kit/pull/1066)