### PR TITLE
minor updates + git fetch cache support

### DIFF
--- a/_examples/golang-basics/Makefile
+++ b/_examples/golang-basics/Makefile
@@ -5,4 +5,7 @@ generate:
 	webrpc-gen -schema=example.ridl -target=go -pkg=main -server -client -out=./example.gen.go
 
 dev-generate:
-	../../bin/webrpc-gen -schema=example.ridl -target=go -pkg=main -server -client -out=./example.gen.go
+	../../bin/webrpc-gen -schema=example.ridl -target=golang -pkg=main -server -client -out=./example.gen.go
+
+dev-generate-local-templates:
+	../../bin/webrpc-gen -schema=example.ridl -target=../../../gen-golang -pkg=main -server -client -out=./example.gen.go

--- a/gen/template_source.go
+++ b/gen/template_source.go
@@ -1,0 +1,224 @@
+package gen
+
+import (
+	"context"
+	"fmt"
+	"hash/fnv"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"text/template"
+	"time"
+
+	"github.com/posener/gitfs"
+	"github.com/shurcooL/httpfs/path/vfspath"
+	"github.com/shurcooL/httpfs/text/vfstemplate"
+	"github.com/shurcooL/httpfs/vfsutil"
+	"github.com/webrpc/webrpc/schema"
+)
+
+func loadTemplates(proto *schema.WebRPCSchema, target string, opts TargetOptions) (*template.Template, error) {
+	s, err := newTemplateSource(proto, target, opts)
+	if err != nil {
+		return nil, err
+	}
+	return s.loadTemplates()
+}
+
+// period of time before we attempt to refetch from git source again.
+// in case of a failure, we will use the local cache.
+const (
+	templateCacheTime              = 1 * time.Hour
+	templateCacheTimestampFilename = ".webrpc-gen-timestamp"
+)
+
+type templateSource struct {
+	tmpl   *template.Template
+	proto  *schema.WebRPCSchema
+	target string
+	opts   TargetOptions
+}
+
+func newTemplateSource(proto *schema.WebRPCSchema, target string, opts TargetOptions) (*templateSource, error) {
+	tmpl := template.New("webrpc-gen").Funcs(templateFuncMap(proto, opts))
+	return &templateSource{
+		tmpl:   tmpl,
+		proto:  proto,
+		target: target,
+		opts:   opts,
+	}, nil
+}
+
+func (s *templateSource) loadTemplates() (*template.Template, error) {
+	if s.isLocalDir(s.target) {
+		// from local directory
+		tmpl, err := s.tmpl.ParseGlob(filepath.Join(s.target, "/*.tmpl"))
+		if err != nil {
+			return nil, fmt.Errorf("failed to load templates from %s: %w", s.target, err)
+		}
+		return tmpl, err
+	} else {
+		// from remote git or cache source
+		s.target = s.inferRemoteTarget(s.target)
+		tmpl, err := s.loadRemote()
+		if err != nil {
+			return nil, fmt.Errorf("failed to load templates from git %s: %w", s.target, err)
+		}
+		return tmpl, err
+	}
+}
+
+func (s *templateSource) loadRemote() (*template.Template, error) {
+	var sourceFS http.FileSystem
+
+	cacheDir, cacheFS, cacheAvailable, cacheTS, err := s.openCacheDir()
+	if err != nil {
+		return nil, err
+	}
+
+	// cache is new, so lets fetch from git
+	if !cacheAvailable || s.opts.RefreshCache || time.Now().Unix()-cacheTS > int64(templateCacheTime.Seconds()) {
+		sourceFS, err = gitfs.New(context.Background(), s.target) //, gitfs.OptPrefetch(true), gitfs.OptGlob("/*.tmpl"))
+
+		if err != nil {
+			// error occured reading from git, if cache is available, use that instead
+			if cacheAvailable {
+				sourceFS = http.Dir(cacheDir)
+			} else {
+				return nil, fmt.Errorf("failed to load templates from remote git repository %s: %w", s.target, err)
+			}
+
+		} else {
+			// using git remote source -- lets cache the files too
+			err := s.syncTemplates(sourceFS, cacheFS, cacheDir)
+			if err != nil {
+				// in case of error, just print a warning and carry on
+				log.Println("[warning] error syncing git templates to local cache:", err.Error())
+			} else {
+				// read from our cache
+				sourceFS = cacheFS
+			}
+		}
+	} else {
+		// load from cache directory
+		sourceFS = cacheFS
+	}
+
+	// parse the template files from the source
+	tmpl, err := vfstemplate.ParseGlob(sourceFS, s.tmpl, "/*.tmpl")
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse templates: %w", err)
+	}
+
+	return tmpl, nil
+}
+
+func (s *templateSource) syncTemplates(remoteFS, cacheFS http.FileSystem, cacheDir string) error {
+	filenames, err := vfspath.Glob(remoteFS, "/*.tmpl")
+	if err != nil {
+		return err
+	}
+
+	for _, filename := range filenames {
+		data, err := vfsutil.ReadFile(remoteFS, filename)
+		if err != nil {
+			return err
+		}
+
+		err = ioutil.WriteFile(filepath.Join(cacheDir, filename), data, 0755)
+		if err != nil {
+			return err
+		}
+	}
+
+	now := time.Now().Unix()
+	data := []byte(fmt.Sprintf("%d", now))
+
+	err = ioutil.WriteFile(filepath.Join(cacheDir, templateCacheTimestampFilename), data, 0755)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *templateSource) openCacheDir() (string, http.FileSystem, bool, int64, error) {
+	cacheDir, _ := s.getTmpCacheDir()
+	if cacheDir == "" {
+		// unable to find OS temp dir, but we don't error -- although
+		// we probably should print a warning
+		return "", nil, false, 0, nil
+	}
+
+	// delete the directory if asked to refresh
+	if s.opts.RefreshCache {
+		os.RemoveAll(cacheDir)
+	}
+
+	// create the directory if it doesn't exist
+	_, err := os.Stat(cacheDir)
+	if !os.IsExist(err) {
+		err := os.MkdirAll(cacheDir, 0755)
+		if err != nil {
+			return "", nil, false, 0, fmt.Errorf("unable to create directory for template cache at %s: %w", cacheDir, err)
+		}
+	}
+
+	// convert local fs to http filesystem
+	cacheFS := http.Dir(cacheDir)
+
+	// read cache timestamp file to determine availability
+	available := false
+	ts := int64(0)
+	b, _ := vfsutil.ReadFile(cacheFS, templateCacheTimestampFilename)
+	if len(b) > 0 {
+		ts, _ = strconv.ParseInt(strings.TrimSpace(string(b)), 10, 64)
+		if ts > 0 {
+			available = true
+		}
+	}
+
+	return cacheDir, cacheFS, available, ts, nil
+}
+
+func (s *templateSource) getTmpCacheDir() (string, error) {
+	dir := os.TempDir()
+	if dir == "" {
+		return "", fmt.Errorf("unable to determine OS temp dir")
+	}
+
+	// derive a deterministic folder for this template source
+	parts := strings.Split(s.target, "/")
+	name := parts[len(parts)-1]
+
+	hash := fnv.New32a()
+	hash.Write([]byte(s.target))
+
+	return filepath.Join(dir, "webrpc-cache", fmt.Sprintf("%d-%s", hash.Sum32(), name)), nil
+}
+
+func (s *templateSource) inferRemoteTarget(target string) string {
+	// extra check to ensure its not a local dir
+	if s.isLocalDir(target) {
+		return target
+	}
+
+	// determine if a url is passed or just a gen-XXX name
+	parts := strings.Split(target, "/")
+
+	// just a name, so by convention assume the default target of the webrpc org
+	if len(parts) == 1 {
+		return fmt.Sprintf("github.com/webrpc/gen-%s", strings.ToLower(target))
+	}
+
+	// accept the target as is
+	return target
+}
+
+func (s *templateSource) isLocalDir(target string) bool {
+	return strings.HasPrefix(target, "/") || strings.HasPrefix(target, ".")
+}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/webrpc/webrpc
 go 1.16
 
 require (
-	github.com/pkg/errors v0.9.1
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/posener/gitfs v1.2.1
 	github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749
 	github.com/stretchr/testify v1.4.0

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -5,9 +5,8 @@ import (
 	"crypto/sha1"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 const (
@@ -34,7 +33,7 @@ type Import struct {
 // the json has been unmarshalled
 func (s *WebRPCSchema) Validate() error {
 	if s.WebRPCVersion != VERSION {
-		return errors.Errorf("webrpc schema version, '%s' is invalid, try '%s'", s.WebRPCVersion, VERSION)
+		return fmt.Errorf("webrpc schema version, '%s' is invalid, try '%s'", s.WebRPCVersion, VERSION)
 	}
 
 	for _, msg := range s.Messages {
@@ -111,7 +110,7 @@ func (s *WebRPCSchema) HasFieldType(fieldType string) (bool, error) {
 	fieldType = strings.ToLower(fieldType)
 	_, ok := DataTypeFromString[fieldType]
 	if !ok {
-		return false, errors.Errorf("webrpc: invalid data type '%s'", fieldType)
+		return false, fmt.Errorf("webrpc: invalid data type '%s'", fieldType)
 	}
 
 	for _, m := range s.Messages {

--- a/schema/service.go
+++ b/schema/service.go
@@ -1,9 +1,8 @@
 package schema
 
 import (
+	"fmt"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 type Service struct {
@@ -41,34 +40,34 @@ func (s *Service) Parse(schema *WebRPCSchema) error {
 	// Service name
 	serviceName := string(s.Name)
 	if string(s.Name) == "" {
-		return errors.Errorf("schema error: service name cannot be empty")
+		return fmt.Errorf("schema error: service name cannot be empty")
 	}
 
 	// Ensure we don't have dupe service names (w/ normalization)
 	name := strings.ToLower(string(s.Name))
 	for _, svc := range schema.Services {
 		if svc != s && name == strings.ToLower(string(svc.Name)) {
-			return errors.Errorf("schema error: duplicate service name detected in service '%s'", serviceName)
+			return fmt.Errorf("schema error: duplicate service name detected in service '%s'", serviceName)
 		}
 	}
 
 	// Ensure methods is defined
 	if len(s.Methods) == 0 {
-		return errors.Errorf("schema error: methods cannot be empty for service '%s'", serviceName)
+		return fmt.Errorf("schema error: methods cannot be empty for service '%s'", serviceName)
 	}
 
 	// Verify method names and ensure we don't have any duplicate method names
 	methodList := map[string]string{}
 	for _, method := range s.Methods {
 		if string(method.Name) == "" {
-			return errors.Errorf("schema error: detected empty method name in service '%s", serviceName)
+			return fmt.Errorf("schema error: detected empty method name in service '%s", serviceName)
 		}
 
 		methodName := string(method.Name)
 		nMethodName := strings.ToLower(methodName)
 
 		if _, ok := methodList[nMethodName]; ok {
-			return errors.Errorf("schema error: detected duplicate method name of '%s' in service '%s'", methodName, serviceName)
+			return fmt.Errorf("schema error: detected duplicate method name of '%s' in service '%s'", methodName, serviceName)
 		}
 		methodList[nMethodName] = methodName
 	}
@@ -86,7 +85,7 @@ func (s *Service) Parse(schema *WebRPCSchema) error {
 
 func (m *Method) Parse(schema *WebRPCSchema, service *Service) error {
 	if service == nil {
-		return errors.Errorf("parse error, service arg cannot be nil")
+		return fmt.Errorf("parse error, service arg cannot be nil")
 	}
 	m.Service = service // back-ref
 	serviceName := string(service.Name)
@@ -95,7 +94,7 @@ func (m *Method) Parse(schema *WebRPCSchema, service *Service) error {
 	for _, input := range m.Inputs {
 		input.InputArg = true // back-ref
 		if input.Name == "" {
-			return errors.Errorf("schema error: detected empty input argument name for method '%s' in service '%s'", m.Name, serviceName)
+			return fmt.Errorf("schema error: detected empty input argument name for method '%s' in service '%s'", m.Name, serviceName)
 		}
 		err := input.Type.Parse(schema)
 		if err != nil {
@@ -107,7 +106,7 @@ func (m *Method) Parse(schema *WebRPCSchema, service *Service) error {
 	for _, output := range m.Outputs {
 		output.OutputArg = true // back-ref
 		if output.Name == "" {
-			return errors.Errorf("schema error: detected empty output name for method '%s' in service '%s'", m.Name, serviceName)
+			return fmt.Errorf("schema error: detected empty output name for method '%s' in service '%s'", m.Name, serviceName)
 		}
 		err := output.Type.Parse(schema)
 		if err != nil {

--- a/schema/var_type.go
+++ b/schema/var_type.go
@@ -4,8 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 type VarType struct {
@@ -30,16 +28,16 @@ func (t *VarType) MarshalJSON() ([]byte, error) {
 
 func (t *VarType) UnmarshalJSON(b []byte) error {
 	if len(b) <= 2 {
-		return errors.Errorf("json error: type cannot be empty")
+		return fmt.Errorf("json error: type cannot be empty")
 	}
 	s := string(b) // string value will be wrapped in quotes
 
 	// validate its a string value
 	if s[0:1] != "\"" {
-		return errors.Errorf("json error: string value is expected")
+		return fmt.Errorf("json error: string value is expected")
 	}
 	if s[len(s)-1:] != "\"" {
-		return errors.Errorf("json error: string value is expected")
+		return fmt.Errorf("json error: string value is expected")
 	}
 
 	// trim string quotes from the json string
@@ -54,7 +52,7 @@ func (t *VarType) UnmarshalJSON(b []byte) error {
 
 func (t *VarType) Parse(schema *WebRPCSchema) error {
 	if t.expr == "" {
-		return errors.Errorf("schema error: type expr cannot be empty")
+		return fmt.Errorf("schema error: type expr cannot be empty")
 	}
 	err := ParseVarTypeExpr(schema, t.expr, t)
 	if err != nil {
@@ -121,7 +119,7 @@ func ParseVarTypeExpr(schema *WebRPCSchema, expr string, vt *VarType) error {
 
 		keyDataType, ok := DataTypeFromString[key]
 		if !ok {
-			return errors.Errorf("schema error: invalid map key type '%s' for expr '%s'", key, expr)
+			return fmt.Errorf("schema error: invalid map key type '%s' for expr '%s'", key, expr)
 		}
 
 		// create sub-type object for map
@@ -139,7 +137,7 @@ func ParseVarTypeExpr(schema *WebRPCSchema, expr string, vt *VarType) error {
 		structExpr := expr
 		msg, ok := getMessageType(schema, structExpr)
 		if !ok || msg == nil {
-			return errors.Errorf("schema error: invalid struct/message type '%s'", structExpr)
+			return fmt.Errorf("schema error: invalid struct/message type '%s'", structExpr)
 		}
 
 		vt.Type = T_Struct
@@ -154,30 +152,30 @@ func ParseVarTypeExpr(schema *WebRPCSchema, expr string, vt *VarType) error {
 
 func parseMapExpr(expr string) (string, string, error) {
 	if !isMapExpr(expr) {
-		return "", "", errors.Errorf("schema error: invalid map expr for '%s'", expr)
+		return "", "", fmt.Errorf("schema error: invalid map expr for '%s'", expr)
 	}
 
 	mapKeyword := DataTypeToString[T_Map]
 	expr = expr[len(mapKeyword):]
 
 	if expr[0:1] != "<" {
-		return "", "", errors.Errorf("schema error: invalid map syntax for '%s'", expr)
+		return "", "", fmt.Errorf("schema error: invalid map syntax for '%s'", expr)
 	}
 	if expr[len(expr)-1:] != ">" {
-		return "", "", errors.Errorf("schema error: invalid map syntax for '%s'", expr)
+		return "", "", fmt.Errorf("schema error: invalid map syntax for '%s'", expr)
 	}
 	expr = expr[1 : len(expr)-1]
 
 	p := strings.Index(expr, ",")
 	if p < 0 {
-		return "", "", errors.Errorf("schema error: invalid map syntax for '%s'", expr)
+		return "", "", fmt.Errorf("schema error: invalid map syntax for '%s'", expr)
 	}
 
 	key := expr[0:p]
 	value := expr[p+1:]
 
 	if !isValidVarKeyType(key) {
-		return "", "", errors.Errorf("schema error: invalid map key '%s' for '%s'", key, expr)
+		return "", "", fmt.Errorf("schema error: invalid map key '%s' for '%s'", key, expr)
 	}
 
 	return key, value, nil

--- a/webrpc.go
+++ b/webrpc.go
@@ -1,11 +1,11 @@
 package webrpc
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 
-	"github.com/pkg/errors"
 	"github.com/webrpc/webrpc/schema"
 	"github.com/webrpc/webrpc/schema/ridl"
 )
@@ -56,6 +56,6 @@ func ParseSchemaFile(schemaFilePath string) (*schema.WebRPCSchema, error) {
 
 		return s, nil
 	} else {
-		return nil, errors.Errorf("error! invalid extension, %s", ext)
+		return nil, fmt.Errorf("error! invalid extension, %s: %w", ext, err)
 	}
 }


### PR DESCRIPTION
* support to search `github.com/webrpc/gen-XXX` for target template source if `-target=NAME` is used, where XXX will be swapped for NAME
* automatically cache downloaded templates from git sources in `${os.TempDir()}/webrpc-cache/${hash}-${genName}` -- the cache will be refreshed automatically each hour, it also is aware of versions in the target path, so it will keep those separate, and it also supports target option to refresh cache if you ask it to
* remove use of github.com/pkg/errors and use just stdlib instead