### PR TITLE
Remove obsolete webrpc version variable

### DIFF
--- a/webrpc.go
+++ b/webrpc.go
@@ -10,8 +10,6 @@ import (
 	"github.com/webrpc/webrpc/schema/ridl"
 )
 
-const VERSION = "v0.6.2"
-
 func ParseSchemaFile(schemaFilePath string) (*schema.WebRPCSchema, error) {
 	cwd, err := os.Getwd()
 	if err != nil {


### PR DESCRIPTION
Remove unused top-level `VERSION` variable. I removed it in #119, but I think it reappeared after I did `git rebase -X theirs master`.

The `VERSION` var was moved over to webrpc-gen https://github.com/webrpc/webrpc/blob/master/gen/version.go#L6 and is passed to the generators as a `{{.WebrpcGenVersion}}` template variable.