### PR TITLE
Schema: Remove unused kind T_Primitive

### DIFF
--- a/schema/data_type.go
+++ b/schema/data_type.go
@@ -37,7 +37,6 @@ const (
 	T_List
 	T_Map
 
-	T_Primitive
 	T_Struct // aka, a reference to our own webrpc proto struct/message
 )
 


### PR DESCRIPTION
I'm not sure if we have any plans for `T_Primitive`, but it's currently unused. All the [basic types](https://github.com/webrpc/webrpc/tree/master/schema#basic-types) has their own kind.