### PR TITLE
Publish webrpc-gen as a Homebrew tap automatically

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,3 +25,4 @@ jobs:
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -22,3 +22,17 @@ checksum:
 changelog:
   use: github
   sort: asc
+
+brews:
+  - name: webrpc-gen
+    tap:
+      owner: webrpc
+      name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+    commit_author:
+      name: goreleaserbot
+      email: bot@goreleaser.com
+    commit_msg_template: "Brew formula update for {{ .ProjectName }} version {{ .Tag }}"
+    homepage: "https://github.com/webrpc/webrpc"
+    description: "generate source code for your target language from webrpc schema"
+    license: "MIT"


### PR DESCRIPTION
Each new `git tag` will release a new version of `webrpc-gen` as a Homebrew tap to https://github.com/webrpc/homebrew-tap repository.

```
brew install webrpc/tap/webrpc-gen
```