### PR TITLE
webrpc-gen v0.8.0: Implement template arrays

### DIFF
--- a/gen/README.md
+++ b/gen/README.md
@@ -262,31 +262,26 @@ See https://pkg.go.dev/text/template#hdr-Functions
 | `mapValueType .MapType`                        | Returns map's value type (ie. `T2` from `map<T1,T2>`) | v0.7.0 |
 | `listElemType .ListType`                       | Returns list's element type (ie. `T` from `[]T`) | v0.7.0 |
 
-| Dictionary                                     | Description                    | webrpc-gen |
+| Dictionary (`map[string]any`)                  | Description                    | webrpc-gen |
 |------------------------------------------------|-------------------------------------------------|-------------|
 | `dict [KEY VALUE]...`                          | Create a new dictionary (`map[string]any`) | v0.7.0 |
 | `get $dict KEY`                                | Get value for the given KEY in dictionary | v0.7.0 |
 | `set $dict KEY VALUE`                          | Set value for the given KEY in dictionary | v0.7.0 |
 | `exists $dict KEY`                             | Returns `true` if the KEY exists in the given dictionary | v0.7.0 |
 
-| Arrays                                         | Description                    | webrpc-gen |
+| String arrays                                  | Description                    | webrpc-gen |
 |------------------------------------------------|-------------------------------------------------|-------------|
 dev/strings#Join)) | v0.7.0 |
-| `first ARRAY`                                  | Return first element from the given string array | v0.7.0 |
-| `last ARRAY`                                   | Return last element from the given string array | v0.7.0 |
+| `array [ELEMENTS]...`                          | Create a new string array | v0.8.0 |
+| `append ARRAY [ELEMENTS]...`                   | Append elements to existing string array | v0.8.0 |
+| `first ARRAY`                                  | Return first element from the given array | v0.7.0 |
+| `join ARRAY SEPARATOR`                         | Join array items with a separator (see [strings.Join()](https://pkg.go.
+| `last ARRAY`                                   | Return last element from the given array | v0.7.0 |
 | `sort ARRAY`                                   | Return sorted copy of the given array (ascending order) | v0.8.0 |
-
-| Generic utils                                  | Description                    | webrpc-gen |
-|------------------------------------------------|-------------------------------------------------|-------------|
-| `coalesce VALUES...`                           | Returns first non-empty value | v0.7.0 |
-| `default VALUE DEFAULT`                        | Returns `DEFAULT` value if given `VALUE` is empty | v0.7.0 |
-| `in FIRST VALUES...`                           | Returns `true` if any of the given VALUES match the `first` value | v0.7.0 |
-| `ternary BOOL FIRST SECOND`                    | Ternary if-else. Returns first value if `true`, second value if `false` | v0.7.0 |
+| `split SEPARATOR STRING`                       | Split string by a separator into array `[]string` | v0.7.0 |
 
 | String utils                                   | Description                    | webrpc-gen |
 |------------------------------------------------|-------------------------------------------------|-------------|
-| `join ARRAY SEPARATOR`                         | Join array items with a separator (see [strings.Join()](https://pkg.go.
-| `split SEPARATOR STRING`                       | Split string by a separator into array `[]string` | v0.7.0 |
 | `hasPrefix STRING PREFIX`                      | Returns `true` if the given string starts with PREFIX | v0.8.0 |
 | `hasSuffix STRING SUFFIX`                      | Returns `true` if the given string ends with SUFFIX | v0.8.0 |
 | `trimPrefix STRING PREFIX`                     | Trim prefix from a given string | v0.8.0 |
@@ -299,3 +294,10 @@ dev/strings#Join)) | v0.7.0 |
 | `pascalCase STRING`                            | Converts input to `"PascalCase"` | v0.7.0 |
 | `snakeCase STRING`                             | Converts input to `"snake_case"` | v0.7.0 |
 | `kebabCase STRING`                             | Converts input to `"kebab-case"` | v0.7.0 |
+
+| Generic utils                                  | Description                    | webrpc-gen |
+|------------------------------------------------|-------------------------------------------------|-------------|
+| `coalesce VALUES...`                           | Returns first non-empty value | v0.7.0 |
+| `default VALUE DEFAULT`                        | Returns `DEFAULT` value if given `VALUE` is empty | v0.7.0 |
+| `in FIRST VALUES...`                           | Returns `true` if any of the given VALUES match the `first` value | v0.7.0 |
+| `ternary BOOL FIRST SECOND`                    | Ternary if-else. Returns first value if `true`, second value if `false` | v0.7.0 |

--- a/gen/README.md
+++ b/gen/README.md
@@ -245,15 +245,14 @@ See https://pkg.go.dev/text/template#hdr-Functions
 
 ## webrpc-gen functions
 
-| Function                                       | Description                    | webrpc-gen |
+| Template flow                                  | Description                    | webrpc-gen |
 |------------------------------------------------|-------------------------------------------------|-------------|
-| `minVersion {{.WebrpcVersion}} v1.4`           | Returns `boolean` if the given major/minor semver is at least v1.4 |
+| `minVersion {{.WebrpcVersion}} v1.4`           | Returns `boolean` if the given major/minor semver is at least v1.4 | v0.7.0 |
 | `stderrPrintf "format %v" ARGS...`             | `printf` to `webrpc-gen` stderr | v0.7.0 |
 | `exit INT`                                     | Terminate template execution, useful for fatal errors | v0.7.0 |
-| `dict [KEY VALUE]...`                          | Create a new dictionary (`map[string]any`) | v0.7.0 |
-| `get $dict KEY`                                | Get value for the given KEY in dictionary | v0.7.0 |
-| `set $dict KEY VALUE`                          | Set value for the given KEY in dictionary | v0.7.0 |
-| `exists $dict KEY`                             | Returns `true` if the KEY exists in the given dictionary | v0.7.0 |
+
+| Schema type helpers                            | Description                    | webrpc-gen |
+|------------------------------------------------|-------------------------------------------------|-------------|
 | `isBasicType .Type`                            | Returns `true` if `.Type` is [basic type](https://github.com/webrpc/webrpc/tree/master/schema#basic-types) | v0.7.0 |
 | `isStructType .Type`                           | Returns `true` if `.Type` is [struct](https://github.com/webrpc/webrpc/tree/master/schema#struct) | v0.7.0 |
 | `isEnumType .Type`                             | Returns `true` if `.Type` is [enum](https://github.com/webrpc/webrpc/tree/master/schema#enum) | v0.7.0 |
@@ -262,15 +261,32 @@ See https://pkg.go.dev/text/template#hdr-Functions
 | `mapKeyType .MapType`                          | Returns map's key type (ie. `T1` from `map<T1,T2>`) | v0.7.0 |
 | `mapValueType .MapType`                        | Returns map's value type (ie. `T2` from `map<T1,T2>`) | v0.7.0 |
 | `listElemType .ListType`                       | Returns list's element type (ie. `T` from `[]T`) | v0.7.0 |
-| `join ARRAY SEPARATOR`                         | Join array items with a separator (see [strings.Join()](https://pkg.go.dev/strings#Join)) | v0.7.0 |
-| `split SEPARATOR STRING`                       | Split string by a separator into array `[]string` | v0.7.0 |
+
+| Dictionary                                     | Description                    | webrpc-gen |
+|------------------------------------------------|-------------------------------------------------|-------------|
+| `dict [KEY VALUE]...`                          | Create a new dictionary (`map[string]any`) | v0.7.0 |
+| `get $dict KEY`                                | Get value for the given KEY in dictionary | v0.7.0 |
+| `set $dict KEY VALUE`                          | Set value for the given KEY in dictionary | v0.7.0 |
+| `exists $dict KEY`                             | Returns `true` if the KEY exists in the given dictionary | v0.7.0 |
+
+| Arrays                                         | Description                    | webrpc-gen |
+|------------------------------------------------|-------------------------------------------------|-------------|
+dev/strings#Join)) | v0.7.0 |
 | `first ARRAY`                                  | Return first element from the given string array | v0.7.0 |
 | `last ARRAY`                                   | Return last element from the given string array | v0.7.0 |
 | `sort ARRAY`                                   | Return sorted copy of the given array (ascending order) | v0.8.0 |
-| `in FIRST VALUES...`                           | Returns `true` if any of the given VALUES match the `first` value | v0.7.0 |
-| `default VALUE DEFAULT`                        | Returns `DEFAULT` value, if given `VALUE` is empty | v0.7.0 |
+
+| Generic utils                                  | Description                    | webrpc-gen |
+|------------------------------------------------|-------------------------------------------------|-------------|
 | `coalesce VALUES...`                           | Returns first non-empty value | v0.7.0 |
+| `default VALUE DEFAULT`                        | Returns `DEFAULT` value if given `VALUE` is empty | v0.7.0 |
+| `in FIRST VALUES...`                           | Returns `true` if any of the given VALUES match the `first` value | v0.7.0 |
 | `ternary BOOL FIRST SECOND`                    | Ternary if-else. Returns first value if `true`, second value if `false` | v0.7.0 |
+
+| String utils                                   | Description                    | webrpc-gen |
+|------------------------------------------------|-------------------------------------------------|-------------|
+| `join ARRAY SEPARATOR`                         | Join array items with a separator (see [strings.Join()](https://pkg.go.
+| `split SEPARATOR STRING`                       | Split string by a separator into array `[]string` | v0.7.0 |
 | `hasPrefix STRING PREFIX`                      | Returns `true` if the given string starts with PREFIX | v0.8.0 |
 | `hasSuffix STRING SUFFIX`                      | Returns `true` if the given string ends with SUFFIX | v0.8.0 |
 | `trimPrefix STRING PREFIX`                     | Trim prefix from a given string | v0.8.0 |

--- a/gen/funcmap.go
+++ b/gen/funcmap.go
@@ -1,10 +1,6 @@
 package gen
 
 import (
-	"fmt"
-	"os"
-	"reflect"
-	"strconv"
 	"strings"
 
 	"github.com/golang-cz/textcase"
@@ -19,12 +15,6 @@ func templateFuncMap(proto *schema.WebRPCSchema, opts map[string]interface{}) ma
 		"exit":         exit,         // v0.7.0
 		"minVersion":   minVersion,   // v0.7.0
 
-		// Dictionary, aka runtime map[string]interface{}.
-		"dict":   dict,   // v0.7.0
-		"get":    get,    // v0.7.0
-		"set":    set,    // v0.7.0
-		"exists": exists, // v0.7.0
-
 		// Schema type helpers.
 		"isBasicType":  isBasicType,  // v0.7.0
 		"isStructType": isStructType, // v0.7.0
@@ -35,16 +25,26 @@ func templateFuncMap(proto *schema.WebRPCSchema, opts map[string]interface{}) ma
 		"mapValueType": mapValueType, // v0.7.0
 		"listElemType": listElemType, // v0.7.0
 
+		// Dictionary, aka runtime map[string]any.
+		"dict":   dict,   // v0.7.0
+		"get":    get,    // v0.7.0
+		"set":    set,    // v0.7.0
+		"exists": exists, // v0.7.0
+
+		// Arrays, aka runtime []any.
+		"first": first,  // v0.7.0
+		"last":  last,   // v0.7.0
+		"sort":  sortFn, // v0.8.0
+
+		// Generic utils.
+		"coalesce": coalesce,  // v0.7.0
+		"default":  defaultFn, // v0.7.0
+		"in":       in,        // v0.7.0
+		"ternary":  ternary,   // v0.7.0
+
 		// String utils.
 		"join":       strings.Join,                                    // v0.7.0
 		"split":      split,                                           // v0.7.0
-		"first":      first,                                           // v0.7.0
-		"last":       last,                                            // v0.7.0
-		"sort":       sortFn,                                          // v0.8.0
-		"in":         in,                                              // v0.7.0
-		"default":    defaultFn,                                       // v0.7.0
-		"coalesce":   coalesce,                                        // v0.7.0
-		"ternary":    ternary,                                         // v0.7.0
 		"hasPrefix":  strings.HasPrefix,                               // v0.7.0
 		"hasSuffix":  strings.HasSuffix,                               // v0.7.0
 		"trimPrefix": strings.TrimPrefix,                              // v0.8.0
@@ -68,116 +68,4 @@ func templateFuncMap(proto *schema.WebRPCSchema, opts map[string]interface{}) ma
 		"snakeCase":  applyStringFunction("snakeCase", textcase.SnakeCase),   // v0.7.0
 		"kebabCase":  applyStringFunction("kebabCase", textcase.KebabCase),   // v0.7.0
 	}
-}
-
-// Similar to "printf" but instead of writing into the generated
-// output file, stderrPrintf writes to webrpc-gen CLI stderr.
-// Useful for printing template errors or for template debugging.
-func stderrPrintf(format string, a ...interface{}) error {
-	_, err := fmt.Fprintf(os.Stderr, format, a...)
-	return err
-}
-
-// Terminate template execution. Useful for fatal errors.
-func exit(code int) error {
-	os.Exit(code)
-	return nil
-}
-
-// Returns true if any of the given values match the first value.
-func in(first interface{}, values ...interface{}) bool {
-	for _, value := range values {
-		if reflect.DeepEqual(first, value) {
-			return true
-		}
-	}
-	return false
-}
-
-// Returns defaultValue, if given value is empty.
-func defaultFn(value interface{}, defaultValue interface{}) interface{} {
-	val := reflect.ValueOf(value)
-	if !val.IsValid() || val.IsZero() {
-		return defaultValue
-	}
-
-	return value
-}
-
-// Returns first non-empty value.
-func coalesce(v ...interface{}) interface{} {
-	for _, v := range v {
-		val := reflect.ValueOf(v)
-		if !val.IsValid() || val.IsZero() {
-			continue
-		}
-		return v
-	}
-	return ""
-}
-
-// Ternary if-else. Returns first value if true, second value if false.
-func ternary(boolean interface{}, first interface{}, second interface{}) interface{} {
-	if toBool(boolean) {
-		return first
-	}
-	return second
-}
-
-func toBool(in interface{}) bool {
-	switch v := in.(type) {
-	case bool:
-		return v
-	case string:
-		if in == "true" {
-			return true
-		}
-		if in == "false" {
-			return false
-		}
-		panic(fmt.Sprintf("unexpected boolean %q", in))
-	default:
-		panic(fmt.Sprintf("unexpected boolean %v", v))
-	}
-}
-
-func minVersion(version string, minVersion string) bool {
-	major, minor, err := parseMajorMinorVersion(version)
-	if err != nil {
-		panic(fmt.Sprintf("minVersion: unexpected version %q", version))
-	}
-
-	minMajor, minMinor, err := parseMajorMinorVersion(minVersion)
-	if err != nil {
-		panic(fmt.Sprintf("minVersion: unexpected min version %q", minVersion))
-	}
-
-	if minMajor > major {
-		return false
-	}
-
-	if minMinor > minor {
-		return false
-	}
-
-	return true
-}
-
-func parseMajorMinorVersion(version string) (major int, minor int, err error) {
-	version = strings.TrimPrefix(version, "v")
-	parts := strings.Split(version, ".")
-
-	major, err = strconv.Atoi(parts[0])
-	if err != nil {
-		return
-	}
-
-	if len(parts) > 1 {
-		minor, err = strconv.Atoi(parts[1])
-		if err != nil {
-			return
-		}
-	}
-
-	return
 }

--- a/gen/funcmap.go
+++ b/gen/funcmap.go
@@ -25,16 +25,20 @@ func templateFuncMap(proto *schema.WebRPCSchema, opts map[string]interface{}) ma
 		"mapValueType": mapValueType, // v0.7.0
 		"listElemType": listElemType, // v0.7.0
 
-		// Dictionary, aka runtime map[string]any.
+		// Dictionary (map[string]any).
 		"dict":   dict,   // v0.7.0
 		"get":    get,    // v0.7.0
 		"set":    set,    // v0.7.0
 		"exists": exists, // v0.7.0
 
-		// Arrays, aka runtime []any.
-		"first": first,  // v0.7.0
-		"last":  last,   // v0.7.0
-		"sort":  sortFn, // v0.8.0
+		// String arrays.
+		"array":  array,        // v0.8.0
+		"append": appendFn,     // v0.8.0
+		"first":  first,        // v0.7.0
+		"join":   strings.Join, // v0.7.0
+		"last":   last,         // v0.7.0
+		"sort":   sortFn,       // v0.8.0
+		"split":  split,        // v0.7.0
 
 		// Generic utils.
 		"coalesce": coalesce,  // v0.7.0
@@ -43,8 +47,6 @@ func templateFuncMap(proto *schema.WebRPCSchema, opts map[string]interface{}) ma
 		"ternary":  ternary,   // v0.7.0
 
 		// String utils.
-		"join":       strings.Join,                                    // v0.7.0
-		"split":      split,                                           // v0.7.0
 		"hasPrefix":  strings.HasPrefix,                               // v0.7.0
 		"hasSuffix":  strings.HasSuffix,                               // v0.7.0
 		"trimPrefix": strings.TrimPrefix,                              // v0.8.0

--- a/gen/funcmap_array.go
+++ b/gen/funcmap_array.go
@@ -1,0 +1,40 @@
+package gen
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+func array(elems ...string) []string {
+	return append([]string{}, elems...)
+}
+
+func appendFn(arr []string, elems ...string) []string {
+	return append(arr, elems...)
+}
+
+func first(elems []string) (string, error) {
+	if len(elems) == 0 {
+		return "", fmt.Errorf("first: no elements in string array")
+	}
+	return elems[0], nil
+}
+
+func last(elems []string) (string, error) {
+	if len(elems) == 0 {
+		return "", fmt.Errorf("last: no elements in string array")
+	}
+	return elems[len(elems)-1], nil
+}
+
+func sortFn(array []string) []string {
+	sorted := make([]string, len(array))
+	copy(sorted, array)
+	sort.Strings(sorted)
+	return sorted
+}
+
+func split(sep string, str string) []string {
+	return strings.Split(str, sep)
+}

--- a/gen/funcmap_flow.go
+++ b/gen/funcmap_flow.go
@@ -1,0 +1,63 @@
+package gen
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// Similar to "printf" but instead of writing into the generated
+// output file, stderrPrintf writes to webrpc-gen CLI stderr.
+// Useful for printing template errors or for template debugging.
+func stderrPrintf(format string, a ...interface{}) error {
+	_, err := fmt.Fprintf(os.Stderr, format, a...)
+	return err
+}
+
+// Terminate template execution. Useful for fatal errors.
+func exit(code int) error {
+	os.Exit(code)
+	return nil
+}
+
+func minVersion(version string, minVersion string) bool {
+	major, minor, err := parseMajorMinorVersion(version)
+	if err != nil {
+		panic(fmt.Sprintf("minVersion: unexpected version %q", version))
+	}
+
+	minMajor, minMinor, err := parseMajorMinorVersion(minVersion)
+	if err != nil {
+		panic(fmt.Sprintf("minVersion: unexpected min version %q", minVersion))
+	}
+
+	if minMajor > major {
+		return false
+	}
+
+	if minMinor > minor {
+		return false
+	}
+
+	return true
+}
+
+func parseMajorMinorVersion(version string) (major int, minor int, err error) {
+	version = strings.TrimPrefix(version, "v")
+	parts := strings.Split(version, ".")
+
+	major, err = strconv.Atoi(parts[0])
+	if err != nil {
+		return
+	}
+
+	if len(parts) > 1 {
+		minor, err = strconv.Atoi(parts[1])
+		if err != nil {
+			return
+		}
+	}
+
+	return
+}

--- a/gen/funcmap_generic.go
+++ b/gen/funcmap_generic.go
@@ -1,0 +1,63 @@
+package gen
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// Returns true if any of the given values match the first value.
+func in(first interface{}, values ...interface{}) bool {
+	for _, value := range values {
+		if reflect.DeepEqual(first, value) {
+			return true
+		}
+	}
+	return false
+}
+
+// Returns defaultValue, if given value is empty.
+func defaultFn(value interface{}, defaultValue interface{}) interface{} {
+	val := reflect.ValueOf(value)
+	if !val.IsValid() || val.IsZero() {
+		return defaultValue
+	}
+
+	return value
+}
+
+// Returns first non-empty value.
+func coalesce(v ...interface{}) interface{} {
+	for _, v := range v {
+		val := reflect.ValueOf(v)
+		if !val.IsValid() || val.IsZero() {
+			continue
+		}
+		return v
+	}
+	return ""
+}
+
+// Ternary if-else. Returns first value if true, second value if false.
+func ternary(boolean interface{}, first interface{}, second interface{}) interface{} {
+	if toBool(boolean) {
+		return first
+	}
+	return second
+}
+
+func toBool(in interface{}) bool {
+	switch v := in.(type) {
+	case bool:
+		return v
+	case string:
+		if in == "true" {
+			return true
+		}
+		if in == "false" {
+			return false
+		}
+		panic(fmt.Sprintf("unexpected boolean %q", in))
+	default:
+		panic(fmt.Sprintf("unexpected boolean %v", v))
+	}
+}

--- a/gen/funcmap_string.go
+++ b/gen/funcmap_string.go
@@ -2,7 +2,6 @@ package gen
 
 import (
 	"fmt"
-	"sort"
 	"strings"
 
 	"github.com/webrpc/webrpc/schema"
@@ -42,29 +41,4 @@ func applyStringFunction(fnName string, fn func(string) string) func(v interface
 			panic(fmt.Errorf("%v: unknown arg type %T", fnName, v))
 		}
 	}
-}
-
-func sortFn(slice []string) []string {
-	sorted := make([]string, len(slice))
-	copy(sorted, slice)
-	sort.Strings(sorted)
-	return sorted
-}
-
-func split(sep string, str string) []string {
-	return strings.Split(str, sep)
-}
-
-func first(elems []string) (string, error) {
-	if len(elems) == 0 {
-		return "", fmt.Errorf("first: no elements in string array")
-	}
-	return elems[0], nil
-}
-
-func last(elems []string) (string, error) {
-	if len(elems) == 0 {
-		return "", fmt.Errorf("last: no elements in string array")
-	}
-	return elems[len(elems)-1], nil
 }

--- a/gen/funcmap_test.go
+++ b/gen/funcmap_test.go
@@ -1,6 +1,9 @@
 package gen
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestMinVersion(t *testing.T) {
 	tt := []struct {
@@ -91,5 +94,38 @@ func TestParseMajorMinorVersion(t *testing.T) {
 		if minor != tc.Minor {
 			t.Errorf("_, minor, _ := parseMajorMinorVersion(%q): got %v, expected %v", tc.Version, minor, tc.Minor)
 		}
+	}
+}
+
+func TestArray(t *testing.T) {
+	arr := array("c", "d")
+	if got := len(arr); got != 2 {
+		t.Errorf("array: expected two elements, got %v", got)
+	}
+
+	arr = appendFn(arr, "a", "b")
+	if got := len(arr); got != 4 {
+		t.Errorf("append: expected four elements, got %v", got)
+	}
+
+	sorted := sortFn(arr)
+	if got := strings.Join(sorted, " "); got != "a b c d" {
+		t.Errorf("sort: expected sorted array, got %v", got)
+	}
+
+	if got, _ := first(sorted); got != "a" {
+		t.Errorf("first: expected a, got %v", got)
+	}
+
+	if got, _ := last(sorted); got != "d" {
+		t.Errorf("last: expected d, got %v", got)
+	}
+
+	if got, err := first([]string{}); err == nil || got != "" {
+		t.Errorf("first(empty): expected error")
+	}
+
+	if got, err := last([]string{}); err == nil || got != "" {
+		t.Errorf("last(empty): expected error")
 	}
 }


### PR DESCRIPTION
Arrays are needed to fix custom struct tags in Golang generator, see https://github.com/webrpc/gen-golang/issues/9.