### PR TITLE
print summary after code generation

### DIFF
--- a/cmd/webrpc-gen/main.go
+++ b/cmd/webrpc-gen/main.go
@@ -17,11 +17,12 @@ var flags = flag.NewFlagSet("webrpc-gen", flag.ExitOnError)
 func main() {
 	versionFlag := flags.Bool("version", false, "print webrpc version and exit")
 	schemaFlag := flags.String("schema", "", "webrpc schema file (required)")
-	targetFlag := flags.String("target", "", fmt.Sprintf("target generator (required), ie. golang@v0.7.0"))
+	targetFlag := flags.String("target", "", "target generator (required), ie. golang or golang@v0.7.0")
 	outFlag := flags.String("out", "", "generated output file, default: stdout")
 	fmtFlag := flags.Bool("fmt", true, "format generated code")
 	refreshCacheFlag := flags.Bool("refreshCache", false, "refresh webrpc cache")
 	testFlag := flags.Bool("test", false, "test schema parsing (skips code-gen)")
+	silentFlag := flags.Bool("silent", false, "silence gen summary")
 
 	// Collect CLI -flags and custom template -options.
 	cliFlags, templateOpts, err := collectCliArgs(flags, os.Args[1:])
@@ -39,7 +40,7 @@ func main() {
 			fmt.Fprintf(os.Stderr, "\nTarget generator usage:\n")
 			templateHelp, err := gen.Generate(&schema.WebRPCSchema{}, *targetFlag, &gen.Config{TemplateOptions: templateOpts})
 			if err != nil {
-				fmt.Fprintln(os.Stderr, templateHelp)
+				fmt.Fprintln(os.Stderr, templateHelp.Code)
 			} else {
 				fmt.Fprintf(os.Stderr, "failed to render -help: %v\n", err)
 			}
@@ -90,7 +91,7 @@ func main() {
 		TemplateOptions: templateOpts,
 	}
 
-	protoGen, err := gen.Generate(schema, *targetFlag, config)
+	genOutput, err := gen.Generate(schema, *targetFlag, config)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())
 		os.Exit(1)
@@ -98,35 +99,29 @@ func main() {
 
 	// Write output to stdout
 	if *outFlag == "" || *outFlag == "stdout" {
-		fmt.Println(protoGen)
+		fmt.Println(genOutput.Code)
 		os.Exit(0)
 	}
 
 	// Write output to a file
-	outfile := *outFlag
-	cwd, err := os.Getwd()
+	err = writeOutfile(*outFlag, []byte(genOutput.Code))
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())
 		os.Exit(1)
 	}
-	if outfile[0:1] != "/" {
-		outfile = filepath.Join(cwd, outfile)
+
+	// Print gen report
+	if *silentFlag {
+		os.Exit(0)
 	}
 
-	outdir := filepath.Dir(outfile)
-	if _, err := os.Stat(outdir); os.IsNotExist(err) {
-		err := os.MkdirAll(outdir, 0755)
-		if err != nil {
-			fmt.Fprintln(os.Stderr, err.Error())
-			os.Exit(1)
-		}
-	}
-
-	err = os.WriteFile(outfile, []byte(protoGen), 0644)
-	if err != nil {
-		fmt.Fprintln(os.Stderr, err.Error())
-		os.Exit(1)
-	}
+	fmt.Println("=========================")
+	fmt.Println("webrpc generated summary:")
+	fmt.Println("=========================")
+	fmt.Println("- schema:", *schemaFlag)
+	fmt.Println("- target:", genOutput.TmplVersion)
+	fmt.Println("- template soruce:", genOutput.TmplDir)
+	fmt.Println("- output file:", *outFlag)
 }
 
 func collectCliArgs(flags *flag.FlagSet, args []string) (cliFlags []string, templateOpts map[string]interface{}, err error) {
@@ -164,4 +159,29 @@ func collectCliArgs(flags *flag.FlagSet, args []string) (cliFlags []string, temp
 	}
 
 	return
+}
+
+func writeOutfile(outfile string, protoGen []byte) error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	if outfile[0:1] != "/" {
+		outfile = filepath.Join(cwd, outfile)
+	}
+
+	outdir := filepath.Dir(outfile)
+	if _, err := os.Stat(outdir); os.IsNotExist(err) {
+		err := os.MkdirAll(outdir, 0755)
+		if err != nil {
+			return err
+		}
+	}
+
+	err = os.WriteFile(outfile, []byte(protoGen), 0644)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }


### PR DESCRIPTION
$ webrpc-gen -schema=example.ridl -target=golang -pkg=main -server -client -out=./example.gen.go
=========================
webrpc generated summary:
=========================
- schema: example.ridl
- target: github.com/webrpc/gen-golang
- template soruce: /var/folders/yg/r7s6qxvx57g5w866ggzln62m0000gn/T/webrpc-cache/2568534563-gen-golang
- output file: ./example.gen.go
