### PR TITLE
Relax template cache invalidation

### DIFF
--- a/cmd/webrpc-gen/main.go
+++ b/cmd/webrpc-gen/main.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/webrpc/webrpc"
 	"github.com/webrpc/webrpc/gen"
@@ -120,6 +121,17 @@ func main() {
 	fmt.Println("=======================================")
 	fmt.Println(" webrpc-gen version :", gen.VERSION)
 	fmt.Println(" target             :", genOutput.TmplVersion)
+	if !genOutput.IsLocal {
+		fmt.Println(" target cache       :", genOutput.TmplDir)
+		cacheAge := "now (refreshed)"
+		if genOutput.CacheAge > 0 {
+			cacheAge = fmt.Sprintf("%v", genOutput.CacheAge.Truncate(time.Second))
+			if genOutput.CacheRefreshErr != nil {
+				cacheAge += fmt.Sprintf(" (failed to refresh: %v)", genOutput.CacheRefreshErr)
+			}
+		}
+		fmt.Println(" target cache age   :", cacheAge)
+	}
 	fmt.Println(" schema file        :", *schemaFlag)
 	fmt.Println(" output file        :", *outFlag)
 }


### PR DESCRIPTION
- Fixes #164
- Refresh cache only if we can fetch all files from remote git
- Fall-back to old (over TTL) cache on git fetch error
- Fetch *.go.tmpl files only (was *.tmpl)
- Pre-fetch all template files when FS is initially loaded
- Print new webrpc-gen cache summary

```
$ webrpc-gen -schema=./tests/schema/api.ridl -target=golang -pkg=client -client -out=./tests/client/client.gen.go
=======================================
|      webrpc generated summary       |
=======================================
 webrpc-gen version : v0.8.x-dev
 target             : github.com/webrpc/gen-golang
 target cache       : /var/folders/23/vc4gzw8n52gc17yx4wfqfj3c0000gn/T/webrpc-cache/2568534563-gen-golang
 target cache age   : 1h51m3s (failed to refresh: get git repository: GET https://api.github.com/repos/webrpc/gen-golang: 403 API rate limit exceeded for 178.248.249.18. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.) [rate reset in 9m42s])
 schema file        : ./tests/schema/api.ridl
 output file        : ./tests/client/client.gen.go
 ```