### PR TITLE
Invalidate Github Actions cache every day

### DIFF
--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -1,0 +1,16 @@
+name: Clean cache
+on:
+  schedule:
+    - cron: "0 0 * * *" # every day (min hour dayOfMonth month dayOfWeek)
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cleanup
+        run: |
+          gh extension install actions/gh-actions-cache
+          gh actions-cache list
+          gh actions-cache delete webrpc-cache --confirm || true
+        env:
+          GH_TOKEN: $


### PR DESCRIPTION
Github cache eviction policy:
- GitHub will remove any cache entries that have not been accessed in over 7 days.