### PR TITLE
Remove unnecessary schema.VarName type

### DIFF
--- a/gen/funcmap_string.go
+++ b/gen/funcmap_string.go
@@ -9,8 +9,6 @@ import (
 
 func toString(v interface{}) string {
 	switch t := v.(type) {
-	case schema.VarName:
-		return string(t)
 	case schema.VarType:
 		return t.String()
 	case *schema.VarType:
@@ -38,8 +36,6 @@ func toString(v interface{}) string {
 func applyStringFunction(fnName string, fn func(string) string) func(v interface{}) string {
 	return func(v interface{}) string {
 		switch t := v.(type) {
-		case schema.VarName:
-			return fn(string(t))
 		case string:
 			return fn(t)
 		default:

--- a/schema/ridl/ridl.go
+++ b/schema/ridl/ridl.go
@@ -143,7 +143,7 @@ func (p *Parser) parse() (*schema.WebRPCSchema, error) {
 	for _, line := range q.root.Enums() {
 		s.Types = append(s.Types, &schema.Type{
 			Kind:   schemaTypeKindEnum,
-			Name:   schema.VarName(line.Name().String()),
+			Name:   line.Name().String(),
 			Fields: []*schema.TypeField{},
 		})
 	}
@@ -152,7 +152,7 @@ func (p *Parser) parse() (*schema.WebRPCSchema, error) {
 	for _, line := range q.root.Structs() {
 		s.Types = append(s.Types, &schema.Type{
 			Kind: schemaTypeKindStruct,
-			Name: schema.VarName(line.Name().String()),
+			Name: line.Name().String(),
 		})
 	}
 
@@ -160,13 +160,13 @@ func (p *Parser) parse() (*schema.WebRPCSchema, error) {
 	for _, service := range q.root.Services() {
 		// push service
 		s.Services = append(s.Services, &schema.Service{
-			Name: schema.VarName(service.Name().String()),
+			Name: service.Name().String(),
 		})
 	}
 
 	// enum fields
 	for _, line := range q.root.Enums() {
-		name := schema.VarName(line.Name().String())
+		name := line.Name().String()
 		enumDef := s.GetTypeByName(string(name))
 
 		if enumDef == nil {
@@ -188,7 +188,7 @@ func (p *Parser) parse() (*schema.WebRPCSchema, error) {
 			}
 
 			enumDef.Fields = append(enumDef.Fields, &schema.TypeField{
-				Name: schema.VarName(key),
+				Name: key,
 				TypeExtra: schema.TypeExtra{
 					Value: val,
 				},
@@ -198,7 +198,7 @@ func (p *Parser) parse() (*schema.WebRPCSchema, error) {
 
 	// struct fields
 	for _, line := range q.root.Structs() {
-		name := schema.VarName(line.Name().String())
+		name := line.Name().String()
 		structDef := s.GetTypeByName(string(name))
 
 		if structDef == nil {
@@ -215,7 +215,7 @@ func (p *Parser) parse() (*schema.WebRPCSchema, error) {
 			}
 
 			field := &schema.TypeField{
-				Name: schema.VarName(fieldName),
+				Name: fieldName,
 				Type: &varType,
 				TypeExtra: schema.TypeExtra{
 					Optional: def.Optional(),
@@ -249,7 +249,7 @@ func (p *Parser) parse() (*schema.WebRPCSchema, error) {
 
 			// push method
 			methods = append(methods, &schema.Method{
-				Name:         schema.VarName(method.Name().String()),
+				Name:         method.Name().String(),
 				StreamInput:  method.StreamInput(),
 				StreamOutput: method.StreamOutput(),
 				Inputs:       inputs,
@@ -300,7 +300,7 @@ func buildArgumentsList(s *schema.WebRPCSchema, args []*ArgumentNode) ([]*schema
 		}
 
 		methodArgument := &schema.MethodArgument{
-			Name:     schema.VarName(arg.Name().String()),
+			Name:     arg.Name().String(),
 			Type:     &varType,
 			Optional: arg.Optional(),
 		}

--- a/schema/service.go
+++ b/schema/service.go
@@ -6,14 +6,14 @@ import (
 )
 
 type Service struct {
-	Name    VarName   `json:"name"`
+	Name    string    `json:"name"`
 	Methods []*Method `json:"methods"`
 
 	Schema *WebRPCSchema `json:"-"` // denormalize/back-reference
 }
 
 type Method struct {
-	Name VarName `json:"name"`
+	Name string `json:"name"`
 
 	StreamInput  bool `json:"streamInput,omitempty"`
 	StreamOutput bool `json:"streamOutput,omitempty"`
@@ -26,7 +26,7 @@ type Method struct {
 }
 
 type MethodArgument struct {
-	Name     VarName  `json:"name"`
+	Name     string   `json:"name"`
 	Type     *VarType `json:"type"`
 	Optional bool     `json:"optional"`
 

--- a/schema/type.go
+++ b/schema/type.go
@@ -14,14 +14,14 @@ const (
 
 type Type struct {
 	Kind      string       `json:"kind"`
-	Name      VarName      `json:"name"`
+	Name      string       `json:"name"`
 	Type      *VarType     `json:"type,omitempty"`
 	Fields    []*TypeField `json:"fields,omitempty"`
 	TypeExtra `json:",omitempty"`
 }
 
 type TypeField struct {
-	Name      VarName  `json:"name"`
+	Name      string   `json:"name"`
 	Type      *VarType `json:"type,omitempty"`
 	TypeExtra `json:",omitempty"`
 }

--- a/schema/var_name.go
+++ b/schema/var_name.go
@@ -1,3 +1,0 @@
-package schema
-
-type VarName string

--- a/schema/var_name.go
+++ b/schema/var_name.go
@@ -1,27 +1,3 @@
 package schema
 
-import (
-	"strings"
-)
-
 type VarName string
-
-// TitleDowncase will downcase the first letter of a string,
-// ie. convert a name form 'FirstName' to 'firstName'
-func (v VarName) TitleDowncase() string {
-	if v == "" {
-		return ""
-	}
-	s := string(v)
-	return strings.ToLower(s[0:1]) + s[1:]
-}
-
-// TitleUpcase will upcase the first letter of a string,
-// ie. convert a name form 'firstName' to 'FirstName'
-func (v VarName) TitleUpcase() string {
-	if v == "" {
-		return ""
-	}
-	s := string(v)
-	return strings.ToUpper(s[0:1]) + s[1:]
-}


### PR DESCRIPTION
Remove unnecessary schema.VarName type

It was difficult to work with schema.VarName (custom string type) in Go templates.
Calling `{{ $type.Name }}` failed with the following error:
      ```
      command failed: template: struct.go.tmpl:9:17: executing "struct" at <.Name>: wrong type for value; expected string; got schema.VarName
      ```

This change will remove type-casting via `{{ printf "%v" $typeName }}` from templates and improve readability.