### PR TITLE
Update the RIDL error syntax & parser

### DIFF
--- a/schema/ridl/error_parser.go
+++ b/schema/ridl/error_parser.go
@@ -2,47 +2,13 @@ package ridl
 
 import (
 	"fmt"
+
+	"github.com/pkg/errors"
 )
 
-func parserStateErrorDefinition(et *ErrorNode) parserState {
-	return func(p *parser) parserState {
-		var err error
-		tok := p.cursor()
-
-		switch tok.tt {
-
-		case tokenQuote:
-			tok, err = p.expectStringValue()
-			if err != nil {
-				return p.stateError(err)
-			}
-			et.message = newTokenNode(tok)
-
-		case tokenMinusSign:
-			matches, err := p.match(tokenDash, tokenDash, tokenWhitespace, tokenWord)
-			if err != nil {
-				return p.stateError(err)
-			}
-			et.httpStatus = newTokenNode(matches[3])
-
-		case tokenWhitespace, tokenNewLine:
-			p.next()
-
-		case tokenHash:
-			p.continueUntilEOL()
-
-		default:
-			p.emit(et)
-			return parserDefaultState
-
-		}
-
-		return parserStateErrorDefinition(et)
-	}
-}
-
+// error <code> <name> <message> [HTTP <status code>]
 func parserStateError(p *parser) parserState {
-	// error <code> <name> <message> [-- <http status code>]
+	// error <code> <name>
 	matches, err := p.match(tokenWord, tokenWhitespace, tokenWord, tokenWhitespace, tokenWord, tokenWhitespace)
 	if err != nil {
 		return p.stateError(err)
@@ -56,8 +22,83 @@ func parserStateError(p *parser) parserState {
 		return p.stateError(fmt.Errorf("expecting error code to be a number but got '%s'", matches[2].val))
 	}
 
-	return parserStateErrorDefinition(&ErrorNode{
+	return parserStateErrorMessage(&ErrorNode{
 		code: newTokenNode(matches[2]),
 		name: newTokenNode(matches[4]),
 	})
+}
+
+// <message> [HTTP <status code>]
+func parserStateErrorMessage(et *ErrorNode) parserState {
+	return func(p *parser) parserState {
+		var err error
+		tok := p.cursor()
+
+		// message, err := p.expectLiteralValue()
+		// if err != nil {
+		// 	return p.stateError(err)
+		// }
+
+		switch tok.tt {
+
+		// "<message>"
+		case tokenQuote:
+			tok, err = p.expectStringValue()
+			if err != nil {
+				return p.stateError(err)
+			}
+			et.message = newTokenNode(tok)
+
+		// <message>
+		case tokenWord:
+			et.message = newTokenNode(tok)
+			p.next()
+
+		default:
+			return p.stateError(errors.Errorf("expected <message> but got %v", tok))
+		}
+
+		return parserStateErrorExplicitStatusCode(et)
+	}
+}
+
+// [HTTP <status code>]
+func parserStateErrorExplicitStatusCode(et *ErrorNode) parserState {
+	return func(p *parser) parserState {
+		// Try to match HTTP
+		matches, err := p.match(tokenWhitespace, tokenWord)
+		if err != nil {
+			if err := p.expectOptionalCommentOrEOL(); err != nil {
+				return p.stateError(err)
+			}
+
+			p.emit(et)
+			return parserDefaultState
+		}
+
+		if err := expectWord(matches[1], "HTTP"); err != nil {
+			p.rewind(1)
+			return p.stateError(fmt.Errorf("expecting optional 'HTTP <status code>' but got '%s'", matches[1].val))
+		}
+
+		// Match <status code>
+		matches, err = p.match(tokenWhitespace, tokenWord)
+		if err != nil {
+			return p.stateError(fmt.Errorf("expecting '<status code>': %w", err))
+		}
+
+		if err := expectNumber(matches[1], matches[1].val); err != nil {
+			p.rewind(1)
+			return p.stateError(fmt.Errorf("expecting HTTP '<status code>' to be a number but got '%s'", matches[1].val))
+		}
+
+		et.httpStatus = newTokenNode(matches[1])
+
+		if err := p.expectOptionalCommentOrEOL(); err != nil {
+			return p.stateError(err)
+		}
+
+		p.emit(et)
+		return parserDefaultState
+	}
 }

--- a/schema/ridl/parser.go
+++ b/schema/ridl/parser.go
@@ -391,7 +391,7 @@ func parserStateDeclaration(p *parser) parserState {
 		//   - <value> [<# comment>]
 		return parserStateImport
 	case wordError:
-		// error <code> <name> <message>
+		// error <code> <name> <message> [HTTP <status code>]
 		return parserStateError
 	case wordEnum:
 		// enum <name>: <type>

--- a/schema/ridl/syntax_error_test.go
+++ b/schema/ridl/syntax_error_test.go
@@ -44,6 +44,5 @@ func TestSyntaxError(t *testing.T) {
 	for i := range syntaxErrors {
 		_, err := parseString(syntaxErrors[i])
 		assert.Error(t, err)
-		t.Logf("%v", err)
 	}
 }


### PR DESCRIPTION
```diff
- error <code> <name> <message> [-- <status code>]
+ error <code> <name> <message> [HTTP <status code>]
```

- Improve error parser error messages.
- Add more error parser tests.
- Add invalid error parser tests.