### PR TITLE
Add built-in webrpc errors

### DIFF
--- a/gen/README.md
+++ b/gen/README.md
@@ -196,9 +196,14 @@ will pass `{{.Opts.name}}`, `{{.Opts.description}}` and `{{.Opts.enableFeature}}
 |------------------------------------------------|--------------------------------|-----------------------------|
 | `{{.SchemaName}}`                              | schema name                    | `"example schema"`          |
 | `{{.SchemaVersion}}`                           | schema version                 | `"v0.0.1"`                  |
-| `{{.SchemaHash}}`                              | `sha1` schema hash             | `483889fb084764e3a256`      |
+| `{{.SchemaHash}}`                              | `sha1` schema hash             | `"483889fb084764e3a256"`    |
+| `{{.WebrpcErrors}}`                            | [webrpc errors](./errors.go)   | array of built-in errors    |
+| `{{.WebrpcErrors[0].Code}}`                    | unique error code              | `-4` (0 or negative number) |
+| `{{.WebrpcErrors[0].Name}}`                    | unique error name              | `"WebrpcBadRequest"`        |
+| `{{.WebrpcErrors[0].Message}}`                 | error description              | `"bad request"`             |
+| `{{.WebrpcErrors[0].HTTPStatus}}`              | HTTP response status code      | `400` (number `400`-`599`)  |
 | `{{.Errors}}`                                  | schema errors                  | array of schema errors      |
-| `{{.Errors[0].Code}}`                          | unique error code              | `1001"` (positive number)   |
+| `{{.Errors[0].Code}}`                          | unique error code              | `1001` (positive number)    |
 | `{{.Errors[0].Name}}`                          | unique error name              | `"RateLimited"`             |
 | `{{.Errors[0].Message}}`                       | error description              | `"rate limited, slow down"` |
 | `{{.Errors[0].HTTPStatus}}`                    | HTTP response status code      | `429` (number `100`-`599`)  |

--- a/gen/errors.go
+++ b/gen/errors.go
@@ -1,0 +1,15 @@
+package gen
+
+import "github.com/webrpc/webrpc/schema"
+
+var WebrpcErrors = []*schema.Error{
+	{Code: 0, Name: "WebrpcEndpoint", Message: "endpoint error", HTTPStatus: 400},
+	{Code: -1, Name: "WebrpcRequestFailed", Message: "request failed"},
+	{Code: -2, Name: "WebrpcBadRoute", Message: "bad route", HTTPStatus: 404},
+	{Code: -3, Name: "WebrpcBadMethod", Message: "bad method", HTTPStatus: 405},
+	{Code: -4, Name: "WebrpcBadRequest", Message: "bad request", HTTPStatus: 400},
+	{Code: -5, Name: "WebrpcBadResponse", Message: "bad response", HTTPStatus: 500},
+	{Code: -6, Name: "WebrpcServerPanic", Message: "server panic", HTTPStatus: 500},
+	// Note: Do not change existing values. Append only.
+	// Keep the list short. Code and Name must be unique.
+}

--- a/gen/gen.go
+++ b/gen/gen.go
@@ -52,6 +52,7 @@ func Generate(proto *schema.WebRPCSchema, target string, config *Config) (out *G
 		WebrpcGenVersion string
 		WebrpcGenCommand string
 		WebrpcTarget     string
+		WebrpcErrors     []*schema.Error
 		Opts             map[string]interface{}
 	}{
 		proto,
@@ -59,6 +60,7 @@ func Generate(proto *schema.WebRPCSchema, target string, config *Config) (out *G
 		webrpc.VERSION,
 		getWebrpcGenCommand(),
 		target,
+		WebrpcErrors,
 		config.TemplateOptions,
 	}
 	if isLocalDir(target) {

--- a/schema/error.go
+++ b/schema/error.go
@@ -17,17 +17,16 @@ type Error struct {
 func (s *Error) Parse(schema *WebRPCSchema) error {
 	s.Name = strings.TrimSpace(s.Name)
 	if s.Name == "" {
-		return fmt.Errorf("schema error: name cannot be empty")
+		return fmt.Errorf("schema error name cannot be empty")
 	}
 	if s.Code <= 0 {
-		return fmt.Errorf("schema error: error code must be positive number")
-	}
-	n := strings.Fields(s.Name)
-	if len(n) > 1 {
-		return fmt.Errorf("schema error: name must be a single word")
+		return fmt.Errorf("schema error code must be positive number")
 	}
 	if !startsWithUpper(s.Name) {
-		return fmt.Errorf("schema error: error name must start with upper case for '%s'", s.Name)
+		return fmt.Errorf("schema error name must start with upper case: '%s'", s.Name)
+	}
+	if strings.HasPrefix(strings.ToLower(s.Name), "webrpc") {
+		return fmt.Errorf("schema error name cannot start with 'Webrpc': '%s'", s.Name)
 	}
 	if s.Message == "" {
 		return fmt.Errorf("schema error: message cannot be empty")

--- a/tests/client/client.go
+++ b/tests/client/client.go
@@ -64,12 +64,12 @@ func RunTests(ctx context.Context, serverURL string) error {
 func testSchemaErrors(ctx context.Context, testApi TestApi) error {
 	tt := []struct {
 		code           int
-		err            RPCError
+		err            WebRPCError
 		name           string
 		msg            string
 		httpStatusCode int
 	}{
-		{code: 0, err: RPCError{Code: 0, HTTPStatus: 400}, name: "WebrpcServerError", msg: "server error", httpStatusCode: 400},
+		{code: 0, err: ErrWebrpcEndpoint, name: "WebrpcEndpoint", msg: "endpoint error", httpStatusCode: 400},
 		{code: 1, err: ErrUnauthorized, name: "Unauthorized", msg: "unauthorized", httpStatusCode: 401},
 		{code: 2, err: ErrExpiredToken, name: "ExpiredToken", msg: "expired token", httpStatusCode: 401},
 		{code: 3, err: ErrInvalidToken, name: "InvalidToken", msg: "invalid token", httpStatusCode: 401},
@@ -96,7 +96,7 @@ func testSchemaErrors(ctx context.Context, testApi TestApi) error {
 			return fmt.Errorf("unexpected error for code=%v:\nexpected: %#v,\ngot:      %#v", tc.code, tc.err, err)
 		}
 
-		rpcErr, _ := err.(RPCError)
+		rpcErr, _ := err.(WebRPCError)
 		if rpcErr.Code != tc.code {
 			return fmt.Errorf("unexpected error code: expected: %v, got: %v", tc.code, rpcErr.Code)
 		}


### PR DESCRIPTION
Pass built-in errors to generators, so we don't need to maintain the list of core webrpc errors in individual templates.