### PR TITLE
Schema errors: HTTP status code must be between 400-599

### DIFF
--- a/schema/error.go
+++ b/schema/error.go
@@ -31,8 +31,8 @@ func (s *Error) Parse(schema *WebRPCSchema) error {
 	if s.Message == "" {
 		return fmt.Errorf("schema error: message cannot be empty")
 	}
-	if s.HTTPStatus < 100 || s.HTTPStatus >= 600 {
-		return fmt.Errorf("schema error: invalid HTTP status code '%v' for error type '%s' (must be number between 100-599)", s.HTTPStatus, s.Name)
+	if s.HTTPStatus < 400 || s.HTTPStatus > 599 {
+		return fmt.Errorf("schema error: invalid HTTP status code '%v' for error type '%s' (must be number between 400-599)", s.HTTPStatus, s.Name)
 	}
 
 	// check for duplicate codes or names


### PR DESCRIPTION
If someone defined HTTP 200 for a schema error, the webrpc clients wouldn't recognize it as an error. Instead, they'd treat the response body as a regular response data object.