### PR TITLE
Implement `webrpc-test -waitForServer -timeout=10s'

### DIFF
--- a/cmd/webrpc-test/main.go
+++ b/cmd/webrpc-test/main.go
@@ -18,77 +18,96 @@ var (
 	flags       = flag.NewFlagSet("webrpc-test", flag.ContinueOnError)
 	clientFlag  = flags.Bool("client", false, "run client tests")
 	serverFlag  = flags.Bool("server", false, "run test server")
+	waitFlag    = flags.Bool("waitForServer", false, "wait for server to be ready")
 	versionFlag = flags.Bool("version", false, "print version and exit")
 	printSchema = flags.Bool("print-schema", false, "obsolete flag (use -printRIDL)") // Obsolete.
 	printRIDL   = flags.Bool("printRIDL", false, "print schema in RIDL")
 	printJSON   = flags.Bool("printJSON", false, "print schema in JSON")
 
 	// webrpc-test -client -url=http://localhost:9988
-	clientFlags = flag.NewFlagSet("webrpc-test -client", flag.ExitOnError)
-	urlFlag     = clientFlags.String("url", "http://localhost:9988", "run client against given server URL")
+	clientFlags   = flag.NewFlagSet("webrpc-test -client", flag.ExitOnError)
+	clientUrlFlag = clientFlags.String("url", "http://localhost:9988", "run client against given server URL")
 
 	// webrpc-test -server -port=9988 -timeout=1m
-	serverFlags = flag.NewFlagSet("webrpc-test -server", flag.ExitOnError)
-	portFlag    = serverFlags.Int("port", 9988, "run server at given port")
-	timeoutFlag = serverFlags.Duration("timeout", time.Minute, "exit after given timeout")
+	serverFlags       = flag.NewFlagSet("webrpc-test -server", flag.ExitOnError)
+	serverPortFlag    = serverFlags.Int("port", 9988, "run server at given port")
+	serverTimeoutFlag = serverFlags.Duration("timeout", time.Minute, "exit after given timeout")
+
+	// webrpc-test -waitForServer -url=http://localhost:9988 -timeout=1m
+	waitFlags       = flag.NewFlagSet("webrpc-test -waitForServer", flag.ExitOnError)
+	waitUrlFlag     = waitFlags.String("url", "http://localhost:9988", "run client against given server URL")
+	waitTimeoutFlag = waitFlags.Duration("timeout", time.Minute, "exit after given timeout")
 )
 
 func main() {
-	if len(os.Args) < 2 {
-		fmt.Fprintf(os.Stderr, "-server or -client flag is required\n")
-		os.Exit(1)
+	if len(os.Args) >= 2 {
+		if err := flags.Parse(os.Args[1:2]); err != nil {
+			os.Exit(1)
+		}
 	}
 
-	_ = flags.Parse(os.Args[1:2])
-
-	if *versionFlag {
+	switch {
+	case *versionFlag:
 		fmt.Println("webrpc-test", webrpc.VERSION)
 		os.Exit(0)
-	}
 
-	if *printRIDL || *printSchema {
+	case *printRIDL, *printSchema:
 		fmt.Println(tests.GetRIDLSchema())
 		os.Exit(0)
-	}
 
-	if *printJSON {
+	case *printJSON:
 		fmt.Println(tests.GetJSONSchema())
 		os.Exit(0)
-	}
 
-	if !*serverFlag && !*clientFlag {
-		fmt.Fprintf(os.Stderr, "-server or -client flag is required\n")
-		os.Exit(1)
-	}
-
-	if *clientFlag {
+	case *clientFlag:
 		if err := clientFlags.Parse(os.Args[2:]); err != nil {
-			fmt.Fprintf(os.Stderr, "%v", err)
+			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}
 
-		err := client.RunTests(context.Background(), *urlFlag)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "%v", err)
+		if err := client.RunTests(context.Background(), *clientUrlFlag); err != nil {
+			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}
 
 		os.Exit(0)
-	}
 
-	if err := serverFlags.Parse(os.Args[2:]); err != nil {
-		fmt.Fprintf(os.Stderr, "%v", err)
-		os.Exit(1)
-	}
+	case *serverFlag:
+		if err := serverFlags.Parse(os.Args[2:]); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
 
-	server, err := server.RunTestServer(fmt.Sprintf("0.0.0.0:%v", *portFlag), *timeoutFlag)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "%v", err)
-		os.Exit(1)
-	}
+		server, err := server.RunTestServer(fmt.Sprintf("0.0.0.0:%v", *serverPortFlag), *serverTimeoutFlag)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
 
-	if err := server.Wait(); err != nil {
-		fmt.Fprintf(os.Stderr, "%v", err)
+		if err := server.Wait(); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+
+		os.Exit(0)
+
+	case *waitFlag:
+		if err := waitFlags.Parse(os.Args[2:]); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+
+		start := time.Now()
+		if err := client.Wait(*waitUrlFlag, *waitTimeoutFlag); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+
+		fmt.Fprintf(os.Stderr, "wait: test server ready in %v\n", time.Since(start).Round(time.Millisecond))
+		os.Exit(0)
+
+	default:
+		flags.Usage()
 		os.Exit(1)
 	}
 }

--- a/cmd/webrpc-test/main.go
+++ b/cmd/webrpc-test/main.go
@@ -49,15 +49,12 @@ func main() {
 	switch {
 	case *versionFlag:
 		fmt.Println("webrpc-test", webrpc.VERSION)
-		os.Exit(0)
 
 	case *printRIDL, *printSchema:
 		fmt.Println(tests.GetRIDLSchema())
-		os.Exit(0)
 
 	case *printJSON:
 		fmt.Println(tests.GetJSONSchema())
-		os.Exit(0)
 
 	case *clientFlag:
 		if err := clientFlags.Parse(os.Args[2:]); err != nil {
@@ -69,8 +66,6 @@ func main() {
 			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}
-
-		os.Exit(0)
 
 	case *serverFlag:
 		if err := serverFlags.Parse(os.Args[2:]); err != nil {
@@ -89,8 +84,6 @@ func main() {
 			os.Exit(1)
 		}
 
-		os.Exit(0)
-
 	case *waitFlag:
 		if err := waitFlags.Parse(os.Args[2:]); err != nil {
 			fmt.Fprintln(os.Stderr, err)
@@ -103,8 +96,7 @@ func main() {
 			os.Exit(1)
 		}
 
-		fmt.Fprintf(os.Stderr, "wait: test server ready in %v\n", time.Since(start).Round(time.Millisecond))
-		os.Exit(0)
+		fmt.Fprintf(os.Stdout, "wait: test server ready in %v\n", time.Since(start).Round(time.Millisecond))
 
 	default:
 		flags.Usage()

--- a/tests/embed.go
+++ b/tests/embed.go
@@ -2,7 +2,6 @@ package tests
 
 import (
 	"embed"
-	_ "embed"
 
 	"github.com/webrpc/webrpc/schema/ridl"
 )


### PR DESCRIPTION
Will remove the need for waiting for the test server readiness via custom scripts, ie.
    https://github.com/webrpc/gen-typescript/blob/a80789817830a8e55480745111eb259da5eeedf6/tests/test.sh#L13-L14