### PR TITLE
Generate code to the output file even on formatting error

### DIFF
--- a/cmd/webrpc-gen/main.go
+++ b/cmd/webrpc-gen/main.go
@@ -122,6 +122,10 @@ func main() {
 	}
 	fmt.Println(" schema file        :", *schemaFlag)
 	fmt.Println(" output file        :", *outFlag)
+	if genOutput.FormatErr != nil {
+		fmt.Println(" format error       :", genOutput.FormatErr)
+		os.Exit(1)
+	}
 }
 
 func collectCliArgs(flags *flag.FlagSet, args []string) (cliFlags []string, templateOpts map[string]interface{}, err error) {

--- a/gen/funcmap_test.go
+++ b/gen/funcmap_test.go
@@ -31,6 +31,8 @@ func TestMinVersion(t *testing.T) {
 		{"v2.5.8", "v2.6", false},
 		{"v2.5.8", "v2.6.0", false},
 		{"v2.5.8", "v2.6.6", false},
+
+		{"v0.13.0-dev", "v0.13.0", true},
 	}
 
 	for _, tc := range tt {

--- a/gen/gen.go
+++ b/gen/gen.go
@@ -20,6 +20,7 @@ type Config struct {
 type GenOutput struct {
 	Code string
 	TemplateSource
+	FormatErr error
 }
 
 func Generate(proto *schema.WebRPCSchema, target string, config *Config) (out *GenOutput, err error) {
@@ -84,15 +85,10 @@ func Generate(proto *schema.WebRPCSchema, target string, config *Config) (out *G
 	}
 
 	if config.Format && isGolangTarget(target) {
-		genCode, err := formatGoSource(b.Bytes())
-		if err != nil {
-			return genOutput, err
-		}
-		genOutput.Code = genCode
-		return genOutput, nil
+		genOutput.Code, genOutput.FormatErr = formatGoSource(b.Bytes())
+	} else {
+		genOutput.Code = b.String()
 	}
-
-	genOutput.Code = b.String()
 
 	return genOutput, nil
 }

--- a/gen/helpers.go
+++ b/gen/helpers.go
@@ -40,7 +40,7 @@ func formatGoSource(source []byte) (string, error) {
 		AllErrors: true, Comments: true, TabIndent: true, TabWidth: 8,
 	})
 	if err != nil {
-		return "", fmt.Errorf("failed to format generated Go source: %w", err)
+		return string(source), fmt.Errorf("failed to format generated Go source: %w", err)
 	}
 	return string(formatted), nil
 }


### PR DESCRIPTION
This is very useful when developing/debugging templates that render invalid code.