### PR TITLE
RIDL parser: Error out if stream is defined per argument type

### DIFF
--- a/schema/ridl/ridl.go
+++ b/schema/ridl/ridl.go
@@ -330,11 +330,10 @@ func buildArgumentsList(s *schema.WebRPCSchema, args []*ArgumentNode) ([]*schema
 
 	// normal form
 	for _, arg := range args {
-
 		var varType schema.VarType
 		err := schema.ParseVarTypeExpr(s, arg.TypeName().String(), &varType)
 		if err != nil {
-			return nil, fmt.Errorf("unknown argument data type: %v", arg.TypeName().String())
+			return nil, fmt.Errorf("parsing argument %v: %w", arg.TypeName(), err)
 		}
 
 		methodArgument := &schema.MethodArgument{

--- a/schema/ridl/type_parser.go
+++ b/schema/ridl/type_parser.go
@@ -133,11 +133,8 @@ loop:
 
 		default:
 			return nil, errUnexpectedToken
-
 		}
 	}
-
-	//return composedValue(tokens)
 
 	return values, nil
 }
@@ -218,7 +215,7 @@ loop:
 
 			switch tok.val {
 
-			case "map":
+			case wordMap:
 				var err error
 
 				tok, err = p.expectMapDefinition()
@@ -228,6 +225,9 @@ loop:
 
 				tokens = append(tokens, tok)
 				continue loop
+
+			case wordStream, wordStruct:
+				return nil, errUnexpectedToken
 			}
 
 			tokens = append(tokens, tok)
@@ -237,8 +237,6 @@ loop:
 		default:
 			return nil, errUnexpectedToken
 		}
-
-		p.next()
 	}
 
 	return composedValue(tokens)


### PR DESCRIPTION
Error out on invalid RIDL:
```
service Chat
  - SubscribeMessages() => (messages: stream Message)
```

should be
```diff
 service Chat
   - SendMessage(authorName: string, text: string)
-  - SubscribeMessages() => (messages: stream Message)
+  - SubscribeMessages() => stream (messages: Message)
```