### PR TITLE
internal comments

### DIFF
--- a/schema/ridl/_example/comments.ridl
+++ b/schema/ridl/_example/comments.ridl
@@ -10,7 +10,7 @@ enum Kind: uint32
   - USER = 1             # user
   - ADMIN = 2            # comment..
 
-# or.. just..
+#! or.. just..
 enum Kind2: uint32
   - USER                 # aka, = 0
   - ADMIN                # aka, = 1

--- a/schema/ridl/lexer.go
+++ b/schema/ridl/lexer.go
@@ -63,6 +63,7 @@ const (
 	tokenDot                         // "."
 	tokenQuestionMark                // "?"
 	tokenRocket                      // "=>"
+	tokenBang                        // "!"
 	tokenWord                        // ..wordCharset..
 
 	tokenExtra // other
@@ -97,6 +98,7 @@ var tokenTypeName = map[tokenType]string{
 	tokenSlash:             "[slash]",
 	tokenQuestionMark:      "[question mark]",
 	tokenRocket:            "[rocket]",
+	tokenBang:              "[bang]",
 	tokenWord:              "[word]",
 	tokenExtra:             "[extra]",
 	tokenComposed:          "[composed]",
@@ -123,6 +125,7 @@ var tokenTypeValue = map[tokenType][]rune{
 	tokenComma:             {','},
 	tokenDot:               {'.'},
 	tokenQuestionMark:      {'?'},
+	tokenBang:              {'!'},
 }
 
 var (
@@ -145,6 +148,7 @@ var (
 	isBackslash         = isTokenType(tokenBackslash)
 	isSlash             = isTokenType(tokenSlash)
 	isDot               = isTokenType(tokenDot)
+	isBang              = isTokenType(tokenBang)
 )
 
 func isTokenType(tt tokenType) func(r rune) bool {

--- a/schema/ridl/parser.go
+++ b/schema/ridl/parser.go
@@ -523,7 +523,9 @@ func parseComments(comments map[int]string, currentLine int) string {
 	for ; currentLine >= 0; currentLine-- {
 		comment, ok := comments[currentLine]
 		if ok {
-			c = append(c, comment)
+			if !strings.HasPrefix(comment, "!") {
+				c = append(c, comment)
+			}
 			delete(comments, currentLine)
 			iteration = 0
 

--- a/schema/ridl/parser_test.go
+++ b/schema/ridl/parser_test.go
@@ -994,10 +994,14 @@ func TestParseServiceComments(t *testing.T) {
 		# Contacts service line 1
 		# Contacts service line 2
 		service ContactsService  # Contacts service line 3
+			#! skip this line
 			# GetContact gives you contact for specific id
 			- GetContact(id: int) => (contact: Contact)
 			# Version returns you current deployed version
+			# 
 			#! skip this line as its internal comment
+			#! skip more lines
+			#! more
 			- Version() => (details: any)
 		`)
 	assert.NoError(t, err)
@@ -1012,5 +1016,5 @@ func TestParseServiceComments(t *testing.T) {
 
 	assert.Equal(t, "Contacts service line 1\nContacts service line 2\nContacts service line 3", serviceNode.comment)
 	assert.Equal(t, "GetContact gives you contact for specific id", serviceNode.methods[0].comment)
-	assert.Equal(t, "Version returns you current deployed version", serviceNode.methods[1].comment)
+	assert.Equal(t, "Version returns you current deployed version\n", serviceNode.methods[1].comment)
 }

--- a/schema/ridl/parser_test.go
+++ b/schema/ridl/parser_test.go
@@ -997,6 +997,7 @@ func TestParseServiceComments(t *testing.T) {
 			# GetContact gives you contact for specific id
 			- GetContact(id: int) => (contact: Contact)
 			# Version returns you current deployed version
+			#! skip this line as its internal comment
 			- Version() => (details: any)
 		`)
 	assert.NoError(t, err)

--- a/schema/ridl/tokenizer.go
+++ b/schema/ridl/tokenizer.go
@@ -16,6 +16,7 @@ func tokenize(src []byte) ([]token, map[int]string, error) {
 
 	commentLine := false
 	commentTokens := []string{}
+
 	for tok := range lx.tokens {
 		if tok.tt == tokenEOF {
 			break


### PR DESCRIPTION
some comments may not want to be published in the .gen output.

I've begun support where if a comment is written as `#! etc etc` the bang after the `#` will denote the line / entry as an internal comment and will not be included in the comments list, it will just be skipped. I've added a test case which should pass once the parser is updated.

also, the parser implementation for comments looks a bit weird, I think we'd be better off writing it like all other parsers, but as long as you can make it work, im not too fussy about it