### PR TITLE
fix parsing comments with http scheme and fqdn

### DIFF
--- a/schema/ridl/_example/example1-golden.json
+++ b/schema/ridl/_example/example1-golden.json
@@ -31,14 +31,14 @@
    "fields": [
     {
      "comments": [
-      "aka , = 0"
+      "aka, = 0"
      ],
      "name": "USER",
      "value": "0"
     },
     {
      "comments": [
-      "aka , = 1"
+      "aka, = 1"
      ],
      "name": "ADMIN",
      "value": "1"
@@ -215,7 +215,7 @@
      "name": "Ping",
      "comments": [
       "comment can go here",
-      "too . . : )"
+      "too .. :)"
      ],
      "inputs": [],
      "outputs": [
@@ -236,7 +236,7 @@
      "name": "Ping",
      "comments": [
       "comment can go here",
-      "too . . : )"
+      "too .. :)"
      ],
      "inputs": [],
      "outputs": [

--- a/schema/ridl/parser_test.go
+++ b/schema/ridl/parser_test.go
@@ -996,6 +996,7 @@ func TestParseServiceComments(t *testing.T) {
 		service ContactsService  # Contacts service line 3
 			#! skip this line
 			# GetContact gives you contact for specific id
+			# see https://docs.opensea.io/docs/metadata-standards
 			- GetContact(id: int) => (contact: Contact)
 			# Version returns you current deployed version
 			# 
@@ -1015,6 +1016,6 @@ func TestParseServiceComments(t *testing.T) {
 	}
 
 	assert.Equal(t, "Contacts service line 1\nContacts service line 2\nContacts service line 3", serviceNode.comment)
-	assert.Equal(t, "GetContact gives you contact for specific id", serviceNode.methods[0].comment)
+	assert.Equal(t, "GetContact gives you contact for specific id\nsee https://docs.opensea.io/docs/metadata-standards", serviceNode.methods[0].comment)
 	assert.Equal(t, "Version returns you current deployed version\n", serviceNode.methods[1].comment)
 }


### PR DESCRIPTION
- check if previous character is whitespace while parsing comments. if charachter is not whitespace we append current comment token to previous