### PR TITLE
update test schema to work with Dart

### DIFF
--- a/tests/schema/test.ridl
+++ b/tests/schema/test.ridl
@@ -50,7 +50,7 @@ struct Complex
   - listOfUsers: []User
   - mapOfUsers: map<string,User>
   - user: User
-  - enum: Status
+  - status: Status
 
 error   1 Unauthorized    "unauthorized"        HTTP 401
 error   2 ExpiredToken    "expired token"       HTTP 401


### PR DESCRIPTION
This PR changes the test schema to use a safe variable name `status` rather than a keyword `enum`, which Dart does not allow.