### PR TITLE
declare the timestamp standard

### DIFF
--- a/gen/README.md
+++ b/gen/README.md
@@ -126,6 +126,8 @@ Require specific `webrpc-gen` version to ensure the API of the template function
 {{- set $typeMap "[]" "array" -}}
 ```
 
+Timestamps must be serialized in JSON to [ECMA Script ISO 8601 format](https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date-time-string-format): `YYYY-MM-DDTHH:mm:ss.sssZ`
+
 Call `{{ get $typeMap .Type }}` to print your type.
 
 ## Split your template into sub-templates

--- a/schema/README.md
+++ b/schema/README.md
@@ -57,7 +57,7 @@ Some example webrpc schemas:
 
 ### Timestamps (date/time)
 
-- `timestamp` - for date/time
+- `timestamp` - for date/time (serialized to [ECMA Script ISO 8601 format](https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date-time-string-format): `YYYY-MM-DDTHH:mm:ss.sssZ`)
 
 
 ## List


### PR DESCRIPTION
Declares the timestamp format to be ECMA Standard's ISO 8601 format. 

closes #278 