### PR TITLE
Fix GoReleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release -f .github/.goreleaser.yml --rm-dist
+          args: release -f .github/.goreleaser.yml --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}


### PR DESCRIPTION
https://goreleaser.com/deprecations/#-rm-dist

```
--rm-dist has been deprecated in favor of --clean.
```

This will fix the GoReleaser pipeline in master.