### PR TITLE
annotation parser improvements

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -208,8 +208,6 @@ github.com/webrpc/gen-kotlin v0.1.0 h1:tnlinqbDgowEoSy8E3VovTdP2OjyOIbgACCbahRjN
 github.com/webrpc/gen-kotlin v0.1.0/go.mod h1:PIPys9Gn1Ro7q7uoacydEX8CtqBlAJSV98A++tdj4ak=
 github.com/webrpc/gen-openapi v0.13.0 h1:+FrIyqdCBkjCbUBD3HJ6mVERJL2mPrhuIsW31BMkb7Y=
 github.com/webrpc/gen-openapi v0.13.0/go.mod h1:fwY3ylZmdiCr+WXjR8Ek8wm08CFRr2/GaXI7Zd/Ou4Y=
-github.com/webrpc/gen-typescript v0.13.0 h1:QgmGmm+OuKZAIDr8Qg/fNLzFem5aUUkH9z+k3OKkf3o=
-github.com/webrpc/gen-typescript v0.13.0/go.mod h1:xQzYnVaSMfcygDXA5SuW8eYyCLHBHkj15wCF7gcJF5Y=
 github.com/webrpc/gen-typescript v0.14.1 h1:cbjdsVbv24uPARIzKh1FWlGPBsVveIWMDEXGNjg3xsU=
 github.com/webrpc/gen-typescript v0.14.1/go.mod h1:xQzYnVaSMfcygDXA5SuW8eYyCLHBHkj15wCF7gcJF5Y=
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=

--- a/schema/ridl/parser.go
+++ b/schema/ridl/parser.go
@@ -167,14 +167,6 @@ func (p *parser) rewind(n int) bool {
 	return true
 }
 
-func (p *parser) prev() bool {
-	if p.pos == 0 {
-		return false
-	}
-	p.pos = p.pos - 1
-	return true
-}
-
 func (p *parser) next() bool {
 	if p.pos >= p.length {
 		return false
@@ -188,15 +180,6 @@ func (p *parser) cursor() *token {
 		return eofToken
 	}
 	return &p.tokens[p.pos]
-}
-
-func (p *parser) goTo(position int) error {
-	if position < 0 || position > p.length {
-		return fmt.Errorf("invalid position")
-	}
-
-	p.pos = position
-	return nil
 }
 
 func (p *parser) expectStringValue() (*token, error) {

--- a/schema/ridl/parser_node.go
+++ b/schema/ridl/parser_node.go
@@ -381,9 +381,10 @@ func (mn *MethodNode) Annotations() []*AnnotationNode {
 type ServiceNode struct {
 	node
 
-	name    *TokenNode
-	methods []*MethodNode
-	comment string
+	name              *TokenNode
+	methods           []*MethodNode
+	methodAnnotations []*AnnotationNode
+	comment           string
 }
 
 func (sn ServiceNode) Type() NodeType {

--- a/schema/ridl/parser_test.go
+++ b/schema/ridl/parser_test.go
@@ -1030,7 +1030,8 @@ func TestParseAnnotations(t *testing.T) {
 		service ContactsService
 			# Version returns you current deployed version
 			@auth:x-access-key
-			@deprecated:Version2 @internal @acl:"admin,member"
+			@deprecated:Version2 @acl:"admin,member"
+			@internal
 			- Version() => (details: any)
 			@internal
 			- Version2() => (details: any)
@@ -1046,16 +1047,17 @@ func TestParseAnnotations(t *testing.T) {
 	}
 
 	require.Len(t, serviceNode.methods[0].annotations, 4)
-	require.Equal(t, "deprecated", serviceNode.methods[0].annotations[0].AnnotationType().String())
-	require.Equal(t, "Version2", serviceNode.methods[0].annotations[0].Value().String())
+	require.Equal(t, "auth", serviceNode.methods[0].annotations[0].AnnotationType().String())
+	require.Equal(t, "x-access-key", serviceNode.methods[0].annotations[0].Value().String())
 
-	require.Equal(t, "internal", serviceNode.methods[0].annotations[1].AnnotationType().String())
+	require.Equal(t, "deprecated", serviceNode.methods[0].annotations[1].AnnotationType().String())
+	require.Equal(t, "Version2", serviceNode.methods[0].annotations[1].Value().String())
 
 	require.Equal(t, "acl", serviceNode.methods[0].annotations[2].AnnotationType().String())
 	require.Equal(t, "admin,member", serviceNode.methods[0].annotations[2].Value().String())
 
-	require.Equal(t, "auth", serviceNode.methods[0].annotations[3].AnnotationType().String())
-	require.Equal(t, "x-access-key", serviceNode.methods[0].annotations[3].Value().String())
+	require.Equal(t, "internal", serviceNode.methods[0].annotations[3].AnnotationType().String())
+	require.Nil(t, serviceNode.methods[0].annotations[3].Value())
 
 	require.Len(t, serviceNode.methods[1].annotations, 1)
 	require.Equal(t, "internal", serviceNode.methods[1].annotations[0].AnnotationType().String())


### PR DESCRIPTION
- Keep parsing intact ( do not parse previous blocks ) and parse annotation and keep them in buffer. 
- Once I start parsing method definition I can assign current state of annotation buffer to this method. 