### PR TITLE
Update to gen-golang@v0.18.0: Support alternative JSON encodings

### DIFF
--- a/_examples/golang-basics/admin/admin.gen.go
+++ b/_examples/golang-basics/admin/admin.gen.go
@@ -19,7 +19,7 @@ import (
 
 const WebrpcHeader = "Webrpc"
 
-const WebrpcHeaderValue = "webrpc;gen-golang@v0.17.0;example@v0.0.1"
+const WebrpcHeaderValue = "webrpc;gen-golang@v0.18.0;example@v0.0.1"
 
 // WebRPC description and code-gen version
 func WebRPCVersion() string {

--- a/_examples/golang-basics/example.gen.go
+++ b/_examples/golang-basics/example.gen.go
@@ -19,7 +19,7 @@ import (
 
 const WebrpcHeader = "Webrpc"
 
-const WebrpcHeaderValue = "webrpc;gen-golang@v0.17.0;example@v0.0.1"
+const WebrpcHeaderValue = "webrpc;gen-golang@v0.18.0;example@v0.0.1"
 
 // WebRPC description and code-gen version
 func WebRPCVersion() string {

--- a/_examples/golang-basics/internal/internal.gen.go
+++ b/_examples/golang-basics/internal/internal.gen.go
@@ -19,7 +19,7 @@ import (
 
 const WebrpcHeader = "Webrpc"
 
-const WebrpcHeaderValue = "webrpc;gen-golang@v0.17.0;example@v0.0.1"
+const WebrpcHeaderValue = "webrpc;gen-golang@v0.18.0;example@v0.0.1"
 
 // WebRPC description and code-gen version
 func WebRPCVersion() string {

--- a/_examples/golang-nodejs/server/server.gen.go
+++ b/_examples/golang-nodejs/server/server.gen.go
@@ -18,7 +18,7 @@ import (
 
 const WebrpcHeader = "Webrpc"
 
-const WebrpcHeaderValue = "webrpc;gen-golang@v0.17.0;example@ v0.0.1"
+const WebrpcHeaderValue = "webrpc;gen-golang@v0.18.0;example@ v0.0.1"
 
 // WebRPC description and code-gen version
 func WebRPCVersion() string {

--- a/_examples/golang-sse/proto/chat.gen.go
+++ b/_examples/golang-sse/proto/chat.gen.go
@@ -22,7 +22,7 @@ import (
 
 const WebrpcHeader = "Webrpc"
 
-const WebrpcHeaderValue = "webrpc;gen-golang@v0.17.0;webrpc-sse-chat@v1.0.0"
+const WebrpcHeaderValue = "webrpc;gen-golang@v0.18.0;webrpc-sse-chat@v1.0.0"
 
 // WebRPC description and code-gen version
 func WebRPCVersion() string {

--- a/_examples/hello-webrpc-ts/server/hello_api.gen.go
+++ b/_examples/hello-webrpc-ts/server/hello_api.gen.go
@@ -18,7 +18,7 @@ import (
 
 const WebrpcHeader = "Webrpc"
 
-const WebrpcHeaderValue = "webrpc;gen-golang@v0.17.0;hello-webrpc@v1.0.0"
+const WebrpcHeaderValue = "webrpc;gen-golang@v0.18.0;hello-webrpc@v1.0.0"
 
 // WebRPC description and code-gen version
 func WebRPCVersion() string {

--- a/_examples/hello-webrpc/server/hello_api.gen.go
+++ b/_examples/hello-webrpc/server/hello_api.gen.go
@@ -18,7 +18,7 @@ import (
 
 const WebrpcHeader = "Webrpc"
 
-const WebrpcHeaderValue = "webrpc;gen-golang@v0.17.0;hello-webrpc@v1.0.0"
+const WebrpcHeaderValue = "webrpc;gen-golang@v0.18.0;hello-webrpc@v1.0.0"
 
 // WebRPC description and code-gen version
 func WebRPCVersion() string {

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/shurcooL/httpfs v0.0.0-20230704072500-f1e31cf0ba5c
 	github.com/stretchr/testify v1.10.0
 	github.com/webrpc/gen-dart v0.1.1
-	github.com/webrpc/gen-golang v0.17.0
+	github.com/webrpc/gen-golang v0.18.0
 	github.com/webrpc/gen-javascript v0.13.0
 	github.com/webrpc/gen-kotlin v0.1.0
 	github.com/webrpc/gen-openapi v0.15.0

--- a/go.sum
+++ b/go.sum
@@ -209,6 +209,8 @@ github.com/webrpc/gen-dart v0.1.1 h1:PZh5oNNdA84Qxu8ixKDf1cT8Iv6t0g7x6q9aeX1bti4
 github.com/webrpc/gen-dart v0.1.1/go.mod h1:yq0ThW3ANNulJLyR50jx1aZMEVBDp19VUHucK65ayPs=
 github.com/webrpc/gen-golang v0.17.0 h1:qCvkhrIdEalQNYJEyqUhKiZ/wK5yEOhx0TJ5X0fzoKM=
 github.com/webrpc/gen-golang v0.17.0/go.mod h1:qy1qEWMlTvrRzjSuQLy+176RqNaX1ymUULDtlo7Dapo=
+github.com/webrpc/gen-golang v0.18.0 h1:ymN3ZPVD3PtYitVZf4M2xmReO3dG+14lKK5OyMMkD6I=
+github.com/webrpc/gen-golang v0.18.0/go.mod h1:t8tIVL/AQhaMteA31xNbzWUrumiMXc7OcKmnNALpnAM=
 github.com/webrpc/gen-javascript v0.13.0 h1:tw7U1xueUjZz3cQAAA4/DZ90BHydkQKiJC4VXd/j2hg=
 github.com/webrpc/gen-javascript v0.13.0/go.mod h1:5EhapSJgzbiWrIGlqzZN9Lg9mE9209wwX+Du2dgn4EU=
 github.com/webrpc/gen-kotlin v0.1.0 h1:tnlinqbDgowEoSy8E3VovTdP2OjyOIbgACCbahRjNcc=

--- a/tests/client/client.gen.go
+++ b/tests/client/client.gen.go
@@ -19,7 +19,7 @@ import (
 
 const WebrpcHeader = "Webrpc"
 
-const WebrpcHeaderValue = "webrpc;gen-golang@v0.17.0;Test@v0.10.0"
+const WebrpcHeaderValue = "webrpc;gen-golang@v0.18.0;Test@v0.10.0"
 
 // WebRPC description and code-gen version
 func WebRPCVersion() string {

--- a/tests/server/server.gen.go
+++ b/tests/server/server.gen.go
@@ -17,7 +17,7 @@ import (
 
 const WebrpcHeader = "Webrpc"
 
-const WebrpcHeaderValue = "webrpc;gen-golang@v0.17.0;Test@v0.10.0"
+const WebrpcHeaderValue = "webrpc;gen-golang@v0.18.0;Test@v0.10.0"
 
 // WebRPC description and code-gen version
 func WebRPCVersion() string {


### PR DESCRIPTION
Support drop-in replacemanet JSON encoding packages, e.g.

`webrpc-gen -target=golang -json=github.com/bytedance/sonic`