### PR TITLE
Update to openapi@v0.16.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/webrpc/gen-golang v0.19.0
 	github.com/webrpc/gen-javascript v0.13.0
 	github.com/webrpc/gen-kotlin v0.1.0
-	github.com/webrpc/gen-openapi v0.16.2
+	github.com/webrpc/gen-openapi v0.16.3
 	github.com/webrpc/gen-typescript v0.17.0
 	golang.org/x/tools v0.30.0
 )

--- a/go.sum
+++ b/go.sum
@@ -215,6 +215,8 @@ github.com/webrpc/gen-kotlin v0.1.0 h1:tnlinqbDgowEoSy8E3VovTdP2OjyOIbgACCbahRjN
 github.com/webrpc/gen-kotlin v0.1.0/go.mod h1:PIPys9Gn1Ro7q7uoacydEX8CtqBlAJSV98A++tdj4ak=
 github.com/webrpc/gen-openapi v0.16.2 h1:YZLJ+DVqlEHP+eygbBoH7KrwDttouZwXvxwVo5izmns=
 github.com/webrpc/gen-openapi v0.16.2/go.mod h1:fwY3ylZmdiCr+WXjR8Ek8wm08CFRr2/GaXI7Zd/Ou4Y=
+github.com/webrpc/gen-openapi v0.16.3 h1:Gwj1Wxdqu+jLsVd+JeUuvf92JyLTZ/nMNcSwVpdqEWs=
+github.com/webrpc/gen-openapi v0.16.3/go.mod h1:fwY3ylZmdiCr+WXjR8Ek8wm08CFRr2/GaXI7Zd/Ou4Y=
 github.com/webrpc/gen-typescript v0.17.0 h1:/tqVK5mgFE8g0di0m9tHTisyAisj3Spw5WkqdOxbkwM=
 github.com/webrpc/gen-typescript v0.17.0/go.mod h1:xQzYnVaSMfcygDXA5SuW8eYyCLHBHkj15wCF7gcJF5Y=
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=


### PR DESCRIPTION
https://github.com/webrpc/gen-openapi/releases/v0.16.3

## What's Changed
* Escape quotes & improve endpoint summary/description by @VojtechVitek in https://github.com/webrpc/gen-openapi/pull/23
* Group service endpoints by OpenAPI tags by @VojtechVitek in https://github.com/webrpc/gen-openapi/pull/24
* generate operation id by @LukasJenicek in https://github.com/webrpc/gen-openapi/pull/25


**Full Changelog**: https://github.com/webrpc/gen-openapi/compare/v0.16.0...v0.16.3