### PR TITLE
Fixes failing sed operation on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ generate: build
 	for i in _examples/*; do echo $$i; make -C $$i generate || exit 1; done
 	# Replace webrpc version in all generated files to avoid git conflicts.
 	git grep -l "$$(git describe --tags)" | xargs sed -i -e "s/@$$(git describe --tags)//g"
-	sed -i "/$$(git describe --tags)/d" tests/schema/test.debug.gen.txt
+	sed -i -e "/$$(git describe --tags)/d" tests/schema/test.debug.gen.txt
 
 # Upgrade Go dependencies
 dep-upgrade-all:


### PR DESCRIPTION
Running `make test` on macOS was failing:

```
=======================================                                                 
|      webrpc generated summary       |                                                 
=======================================                                                 
 webrpc-gen version : v0.36.1-3-gc43c6da                                                
 target             : github.com/webrpc/gen-typescript@v0.20.1                          
 target cache       : /var/folders/cc/327q_y9x079d3ppd_tdqgl500000gn/T/webrpc-cache/232 
2951561-gen-typescript@v0.20.1                                                          
 target cache age   : now (refreshed)                                                   
 schema file        : proto/chat.ridl                                                   
 output file        : webapp/src/rpc.gen.ts                                             
# Replace webrpc version in all generated files to avoid git conflicts.                 
git grep -l "$(git describe --tags)" | xargs sed -i -e "s/@$(git describe --tags)//g"   
sed -i "/$(git describe --tags)/d" tests/schema/test.debug.gen.txt                      
sed: 2: "tests/schema/test.debug ...": undefined label 'ests/schema/test.debug.gen.txt' 
make: *** [generate] Error 1   
```

The fix: added -e flag to the sed -i call on line 34. On macOS, sed -i requires a backup extension argument — without one, it was interpreting the pattern as the extension, causing the "undefined label" error. The -e flag serves double duty: macOS sed treats it as an empty-like backup extension, and it also works correctly on Linux.

We are already using `sed -i -e` in other places in the Makefile as well.
