### PR TITLE
fix(ridl): deduplicate errors on diamond import

### DIFF
--- a/schema/ridl/ridl.go
+++ b/schema/ridl/ridl.go
@@ -188,7 +188,7 @@ func (p *Parser) parse() (*schema.WebRPCSchema, error) {
 				}
 			}
 			for i := range imported.Errors {
-				if isImportAllowed(imported.Errors[i].Name, members) {
+				if !slices.Contains(s.Errors, imported.Errors[i]) && isImportAllowed(imported.Errors[i].Name, members) {
 					s.Errors = append(s.Errors, imported.Errors[i])
 				}
 			}

--- a/schema/ridl/ridl_test.go
+++ b/schema/ridl/ridl_test.go
@@ -167,6 +167,61 @@ func TestRIDLImports(t *testing.T) {
 	}
 }
 
+// TestRIDLImportsDiamondErrors exercises the diamond-import case where two
+// sibling schemas each import a shared errors file. The shared file's errors
+// must be deduplicated — not rejected as duplicate declarations.
+func TestRIDLImportsDiamondErrors(t *testing.T) {
+	fsys := fstest.MapFS{
+		"schema/main.ridl": {Data: []byte(`
+			webrpc = v1
+			version = v0.1.0
+			name = main
+
+			import
+			- dashboard.ridl
+			- backoffice.ridl
+			`)},
+		"schema/dashboard.ridl": {Data: []byte(`
+			webrpc = v1
+			version = v0.1.0
+			name = dashboard
+
+			import
+			- errors.ridl
+
+			service Dashboard
+			  - Ping() => (version: string)
+			`)},
+		"schema/backoffice.ridl": {Data: []byte(`
+			webrpc = v1
+			version = v0.1.0
+			name = backoffice
+
+			import
+			- errors.ridl
+
+			service Backoffice
+			  - Ping() => (version: string)
+			`)},
+		"schema/errors.ridl": {Data: []byte(`
+			webrpc = v1
+			version = v0.1.0
+			name = errors
+
+			error 1000 Unauthorized "unauthorized access" HTTP 401
+			error 1001 Forbidden    "forbidden"           HTTP 403
+			`)},
+	}
+
+	s, err := NewParser(fsys, "/", "schema/main.ridl").Parse()
+	require.NoError(t, err)
+
+	if assert.Equal(t, 2, len(s.Errors)) {
+		assert.Equal(t, "Unauthorized", string(s.Errors[0].Name))
+		assert.Equal(t, "Forbidden", string(s.Errors[1].Name))
+	}
+}
+
 func TestRIDLImportsCycle(t *testing.T) {
 	fsys := fstest.MapFS{
 		"schema/a.ridl": {Data: []byte(`

--- a/tests/client/client.gen.go
+++ b/tests/client/client.gen.go
@@ -612,7 +612,7 @@ var (
 
 const WebrpcHeader = "Webrpc"
 
-const WebrpcHeaderValue = "webrpc;gen-golang@v0.27.1;Test@v1.0.0"
+const WebrpcHeaderValue = "webrpc;gen-golang@v0.28.0;Test@v1.0.0"
 
 type WebrpcGenVersions struct {
 	WebrpcGenVersion string

--- a/tests/server/server.gen.go
+++ b/tests/server/server.gen.go
@@ -859,7 +859,7 @@ var (
 
 const WebrpcHeader = "Webrpc"
 
-const WebrpcHeaderValue = "webrpc;gen-golang@v0.27.1;Test@v1.0.0"
+const WebrpcHeaderValue = "webrpc;gen-golang@v0.28.0;Test@v1.0.0"
 
 type WebrpcGenVersions struct {
 	WebrpcGenVersion string


### PR DESCRIPTION
## Problem

When schema A imports B and C, and both B and C import the same `errors.ridl`, `make generate` fails:

```
schema error: detected duplicate error name of 'Unauthorized'
```

Repro (failing test added in this PR as `TestRIDLImportsDiamondErrors`): `main.ridl` imports `dashboard.ridl` and `backoffice.ridl`; both import `errors.ridl`. Parsing `main.ridl` fails even though `errors.ridl` is the *same file* — same `*Error` instance via the parser cache.

Types and enums don't have this bug. This PR closes the asymmetry.

## Root cause

[`schema/ridl/ridl.go:165-200`](https://github.com/webrpc/webrpc/blob/master/schema/ridl/ridl.go#L165-L200) imports declarations from every `import` line. The parser caches parse results per path, so a diamond-imported file yields the identical `*Type` / `*Error` / `*Service` pointer on both paths.

- Types: `slices.Contains(s.Types, imported.Types[i])` skips duplicate pointers. ✓
- **Errors: no dedup check — every import appends.** ✗
- Services: also no dedup check. (Services haven't hit this in practice because webrpc forbids re-declaring a service name; I've left services unchanged to keep the fix minimal.)

Later, [`schema/error.go:Error.Parse()`](https://github.com/webrpc/webrpc/blob/master/schema/error.go) walks `s.Errors` and rejects any repeated name. Since errors weren't deduped at import time, diamond imports trip the validator.

## Fix

One line in the import loop. Mirror the struct path:

```diff
 for i := range imported.Errors {
-    if isImportAllowed(imported.Errors[i].Name, members) {
+    if !slices.Contains(s.Errors, imported.Errors[i]) && isImportAllowed(imported.Errors[i].Name, members) {
         s.Errors = append(s.Errors, imported.Errors[i])
     }
 }
```

## Behavior after this change

| Scenario | Before | After |
|---|---|---|
| Diamond import of the same `errors.ridl` | ❌ `detected duplicate error name` | ✅ deduped |
| Two different files declaring an error with the same name | ❌ `detected duplicate error name` | ❌ `detected duplicate error name` (unchanged — caught by the name-based validator in `schema/error.go`) |
| Two different files declaring different errors with the same HTTP code | ❌ caught by code check | ❌ caught by code check (unchanged) |

Pointer equality only succeeds for the genuine re-import case. Real conflicts still fail at validation.

## Test plan
- [x] New `TestRIDLImportsDiamondErrors` covers `main → {dashboard, backoffice} → errors` diamond
- [x] Test fails before the fix with the exact error message, passes after
- [x] `go test ./schema/...` — all existing tests still pass