### PR TITLE
feat(gen): add -omitSchemaHash flag to omit schema hash from output

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,24 @@ webrpc-gen -schema=example.ridl -target=golang -pkg=main -server -client -out=./
 and see the generated `./example.gen.go` file of types, server and client in Go. This is essentially
 how the [golang-basics](./_examples/golang-basics) example was built.
 
+## Omitting the schema hash
+
+By default, generated code embeds a `WebRPCSchemaHash` — a fingerprint (SHA1) of your schema. webrpc
+itself never compares it; it's an informational value you can surface yourself (for example, via a
+`Version` RPC) to detect when a client and server were generated from different schema versions
+(schema drift). Because this hash changes on any schema edit, two concurrent PRs that both regenerate
+code will conflict on the hash line.
+
+Pass `-omitSchemaHash` to leave the hash empty in the generated output:
+
+```
+webrpc-gen -schema=example.ridl -target=golang -pkg=main -server -client -omitSchemaHash -out=./example.gen.go
+```
+
+The hash value becomes constant across regenerations, so it no longer causes merge conflicts. The
+only thing you lose is the fingerprint itself — so omit it unless you actually read `WebRPCSchemaHash()`
+somewhere to detect schema drift.
+
 
 ## Example apps
 

--- a/cmd/webrpc-gen/main.go
+++ b/cmd/webrpc-gen/main.go
@@ -27,6 +27,7 @@ var (
 	methodTreeShakeFlag = flags.Bool("methodTreeShake", false, "remove unused types of omitted services when using -service flag")
 	ignoreFlag          = flags.String("ignore", "", "ignore service methods with specific annotations separated by commas")
 	matchFlag           = flags.String("match", "", "match service methods with specific annotations separated by commas")
+	omitSchemaHashFlag  = flags.Bool("omitSchemaHash", false, "omit the schema hash from generated output (avoids merge conflicts; removes the fingerprint used to detect client/server schema drift)")
 )
 
 func main() {
@@ -113,6 +114,7 @@ func main() {
 	config := &gen.Config{
 		RefreshCache:    *refreshCacheFlag,
 		Format:          *fmtFlag,
+		OmitSchemaHash:  *omitSchemaHashFlag,
 		TemplateOptions: templateOpts,
 	}
 

--- a/gen/gen.go
+++ b/gen/gen.go
@@ -15,6 +15,7 @@ import (
 type Config struct {
 	RefreshCache    bool
 	Format          bool
+	OmitSchemaHash  bool
 	TemplateOptions map[string]interface{}
 }
 
@@ -49,10 +50,15 @@ func Generate(proto *schema.WebRPCSchema, target string, config *Config) (out *G
 		proto.BasePath = "/rpc/"
 	}
 
-	// Generate deterministic schema hash of the proto file
-	schemaHash, err := proto.SchemaHash()
-	if err != nil {
-		return nil, err
+	// Generate deterministic schema hash of the proto file. When OmitSchemaHash
+	// is set, the hash is left empty so it never appears in generated output,
+	// avoiding merge conflicts on the hash line across concurrent PRs.
+	var schemaHash string
+	if !config.OmitSchemaHash {
+		schemaHash, err = proto.SchemaHash()
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	vars := TemplateVars{
@@ -145,11 +151,15 @@ func webRPCGenHeader(t TemplateVars) string {
 	codeGen := fmt.Sprintf("%s@%s", t.CodeGenName, codeGenVersion)
 
 	var schemaVersion string
-	// schema version is empty we use schemaHash instead
-	if t.SchemaVersion == "" {
-		schemaVersion = fmt.Sprintf("%s@v0.0.0-%s", t.SchemaName, t.SchemaHash)
-	} else {
+	switch {
+	case t.SchemaVersion != "":
 		schemaVersion = fmt.Sprintf("%s@%s", t.SchemaName, t.SchemaVersion)
+	case t.SchemaHash != "":
+		// schema version is empty, we use schemaHash instead
+		schemaVersion = fmt.Sprintf("%s@v0.0.0-%s", t.SchemaName, t.SchemaHash)
+	default:
+		// no schema version and hash omitted
+		schemaVersion = fmt.Sprintf("%s@v0.0.0", t.SchemaName)
 	}
 
 	return fmt.Sprintf("%s;%s;%s", webrpcGenVersion, codeGen, schemaVersion)

--- a/gen/gen_test.go
+++ b/gen/gen_test.go
@@ -1,0 +1,56 @@
+package gen
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/webrpc/webrpc/schema"
+)
+
+func TestWebRPCGenHeaderSchemaVersion(t *testing.T) {
+	tt := []struct {
+		name          string
+		schemaName    string
+		schemaVersion string
+		schemaHash    string
+		wantSuffix    string
+	}{
+		{
+			name:          "versioned schema ignores hash",
+			schemaName:    "svc",
+			schemaVersion: "v2.0.0",
+			schemaHash:    "abc123",
+			wantSuffix:    "svc@v2.0.0",
+		},
+		{
+			name:       "unversioned schema falls back to hash",
+			schemaName: "svc",
+			schemaHash: "abc123",
+			wantSuffix: "svc@v0.0.0-abc123",
+		},
+		{
+			name:       "unversioned schema with omitted hash has no dangling dash",
+			schemaName: "svc",
+			schemaHash: "",
+			wantSuffix: "svc@v0.0.0",
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			header := webRPCGenHeader(TemplateVars{
+				WebRPCSchema: &schema.WebRPCSchema{
+					SchemaName:    tc.schemaName,
+					SchemaVersion: tc.schemaVersion,
+				},
+				SchemaHash: tc.schemaHash,
+			})
+
+			// The schema-version segment is the third ";"-delimited field.
+			fields := strings.Split(header, ";")
+			require.Len(t, fields, 3, "header %q should have 3 fields", header)
+			require.Equal(t, tc.wantSuffix, fields[2])
+		})
+	}
+}

--- a/tests/client/client.gen.go
+++ b/tests/client/client.gen.go
@@ -612,7 +612,7 @@ var (
 
 const WebrpcHeader = "Webrpc"
 
-const WebrpcHeaderValue = "webrpc;gen-golang@v0.28.0;Test@v1.0.0"
+const WebrpcHeaderValue = "webrpc;gen-golang@v0.28.1;Test@v1.0.0"
 
 type WebrpcGenVersions struct {
 	WebrpcGenVersion string

--- a/tests/server/server.gen.go
+++ b/tests/server/server.gen.go
@@ -859,7 +859,7 @@ var (
 
 const WebrpcHeader = "Webrpc"
 
-const WebrpcHeaderValue = "webrpc;gen-golang@v0.28.0;Test@v1.0.0"
+const WebrpcHeaderValue = "webrpc;gen-golang@v0.28.1;Test@v1.0.0"
 
 type WebrpcGenVersions struct {
 	WebrpcGenVersion string


### PR DESCRIPTION
## Problem

The generated `WebRPCSchemaHash` is a SHA1 fingerprint of the entire schema, so it changes on **any** schema edit. When two PRs both regenerate code, each produces a different hash on the same line — whichever merges second hits a conflict.

## Solution

Add a `-omitSchemaHash` CLI flag that leaves the hash empty in generated output, making the value constant across regenerations and eliminating those conflicts.

The flag is handled **centrally** in `gen/gen.go` (it blanks `vars.SchemaHash` before template execution), so **all existing generator templates work unchanged** — no `gen-*` repos need updating.

## Changes

- **`cmd/webrpc-gen/main.go`** — new reserved `-omitSchemaHash` boolean flag, threaded into `gen.Config`.
- **`gen/gen.go`** — added `Config.OmitSchemaHash`; `Generate` skips hash computation when set; `webRPCGenHeader` hardened so an unversioned schema with an empty hash yields `name@v0.0.0` instead of a dangling `name@v0.0.0-`.
- **`gen/gen_test.go`** — table-driven test covering all three header cases (versioned, unversioned + hash, unversioned + omitted).
- **`README.md`** — new *"Omitting the schema hash"* section documenting the flag and its tradeoff.

## Behavior

| | header line | `WebRPCSchemaHash()` |
|---|---|---|
| default | `// example v1.0.0 8f87db6c…` | `return "8f87db6c…"` |
| `-omitSchemaHash` | `// example v1.0.0` | `return ""` |

## Tradeoff

The hash is an **informational fingerprint** — webrpc never compares it at runtime. The only thing omitting it costs is the ability to surface `WebRPCSchemaHash()` yourself (e.g. via a `Version` RPC) to detect client/server schema drift. Off by default, so existing behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)