### PR TITLE
comment fix about error list delimiters

### DIFF
--- a/schema/ridl/service_parser.go
+++ b/schema/ridl/service_parser.go
@@ -107,7 +107,7 @@ func parseStateServiceMethodDefinition(sn *ServiceNode) parserState {
 		// Check for optional errors clause
 		matches, err = p.match(tokenWhitespace, tokenWord)
 		if err == nil && matches[1].val == wordErrors {
-			// Parse comma-separated list of error names
+			// Parse bar-separated list of error names
 			errorNames, err := p.expectErrorList()
 			if err != nil {
 				return p.stateError(err)


### PR DESCRIPTION
The comment about parsing error lists says they are delimited by commas, but the source code seems to indicate that they are instead bars.