### PR TITLE
ci: group dependabot updates into a single weekly PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,40 @@
+version: 2
+
+# Combine every ecosystem's updates into a single weekly PR instead of one
+# PR per dependency. See the "all-dependencies" multi-ecosystem group below.
+multi-ecosystem-groups:
+  all-dependencies:
+    schedule:
+      interval: "weekly"
+
+updates:
+  # Root module + every _examples/* module.
+  - package-ecosystem: "gomod"
+    directories:
+      - "/"
+      - "/_examples/**"
+    patterns: ["*"]
+    multi-ecosystem-group: "all-dependencies"
+
+  # Example webapps / node servers.
+  - package-ecosystem: "npm"
+    directories:
+      - "/_examples/**"
+    patterns: ["*"]
+    multi-ecosystem-group: "all-dependencies"
+    cooldown:
+      default-days: 14
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    patterns: ["*"]
+    multi-ecosystem-group: "all-dependencies"
+    cooldown:
+      default-days: 14
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    patterns: ["*"]
+    multi-ecosystem-group: "all-dependencies"
+    cooldown:
+      default-days: 14


### PR DESCRIPTION
Dependabot currently opens one PR per dependency (it's running in security-updates mode with no config file), which floods the PR list. This adds a `dependabot.yml` that bundles all ecosystems into a single weekly PR via a multi-ecosystem group, mirroring the config we use in omsx.

---

## What changed

`.github/dependabot.yml` defines one `all-dependencies` multi-ecosystem group on a weekly schedule, covering:

- `gomod` — root module + every `/_examples/**` module
- `npm` — `/_examples/**` webapps and node servers
- `github-actions` — `/`
- `docker` — `/` (root `Dockerfile`)

All non-gomod ecosystems get a 14-day cooldown to avoid churn on fresh releases.

## Notes

- Adding `updates:` also turns on Dependabot **version** updates (scheduled), not just security updates — that's the intended behavior here, and all of them land in the single grouped PR.
- The grouped PR replaces the per-dependency spray going forward; the existing open per-dep PRs are being rebased and merged separately.
