### PR TITLE
fix(tests): use errors.New for non-constant error string

### DIFF
--- a/tests/client/client.go
+++ b/tests/client/client.go
@@ -93,7 +93,7 @@ func RunTests(ctx context.Context, serverURL string) error {
 		for _, err := range errs {
 			fmt.Fprintf(&b, "%v\n", err)
 		}
-		return fmt.Errorf(b.String())
+		return errors.New(b.String())
 	}
 
 	return nil


### PR DESCRIPTION
Dependency-bump PRs that touch the root `go.mod` (e.g. the go-git/go-billy bumps) were failing CI on `go vet` — not because of the dependency, but because bumping the root module busts the cached vet result and re-runs vet under Go 1.24+, which rejects `fmt.Errorf` with a non-constant format string. The offending call is long-standing committed code in the test client.

---

## Change

`tests/client/client.go:96`: `fmt.Errorf(b.String())` → `errors.New(b.String())`. `b.String()` is an assembled message, not a format string, so `errors.New` is the correct call. `errors` is already imported.

## Test plan

```
$ go vet -C tests ./client/
(clean, no output)
```

Generated `*.gen.go` files use `fmt.Errorf(format, args...)` legitimately and are untouched.
