### PR TITLE
fix(build): use perl -i for portable in-place edits in generate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,10 +30,10 @@ generate: build
 	go generate -v -x ./...
 	for i in _examples/*; do echo $$i; make -C $$i generate || exit 1; done
 	# Replace webrpc version in all generated files to avoid git conflicts.
-	git grep -l "$$(git describe --tags)" | xargs sed -i -e "s/@$$(git describe --tags)//g"
-	sed -i "/$$(git describe --tags)/d" tests/schema/test.debug.gen.txt
+	git grep -l "$$(git describe --tags)" | xargs perl -i -pe "s/\@$$(git describe --tags)//g"
+	perl -i -ne "print unless /$$(git describe --tags)/" tests/schema/test.debug.gen.txt
 	# Strip code-generator versions (gen-<name>@vX.Y.Z) from generated files so dependency bumps don't churn them.
-	git grep -lE "gen-[a-z]+@v[0-9]" -- _examples tests | xargs sed -i -e "s/\(gen-[a-z][a-z]*\)@v[0-9][0-9.]*/\1/g"
+	git grep -lE "gen-[a-z]+@v[0-9]" -- _examples tests | xargs perl -i -pe 's/(gen-[a-z]+)\@v[0-9][0-9.]*/$$1/g'
 
 # Upgrade Go dependencies
 dep-upgrade-all:


### PR DESCRIPTION
macOS devs couldn't run `make generate`: BSD `sed -i` needs a backup-suffix argument, and the `sed -i -e` form that's used throughout the target "works" only by having `-i` swallow `-e` as the suffix — which writes stray `<file>-e` backup files that aren't gitignored and are one `git add -A` away from being committed. Switching the in-place edits to `perl -i` (no suffix) behaves identically on GNU/Linux and BSD/macOS and leaves nothing behind, fixing all three sites at once.

This supersedes #442, which fixed only the single `test.debug.gen.txt` line (and still left the `-e` litter on the two `xargs` lines).

---

## Changes

All three in-place edits in the `generate` target switched from `sed -i` to `perl -i`:

| Line | Before | After |
|------|--------|-------|
| 33 | `xargs sed -i -e "s/@$(git describe --tags)//g"` | `xargs perl -i -pe "s/\@$(git describe --tags)//g"` |
| 34 | `sed -i "/$(git describe --tags)/d" …` | `perl -i -ne "print unless /$(git describe --tags)/" …` |
| 36 | `xargs sed -i -e "s/\(gen-…\)@v…/\1/g"` | `xargs perl -i -pe 's/(gen-…)\@v…/$1/g'` |

Notes:
- Lines 33/34 keep double quotes (they need `$(git describe --tags)` command substitution). Line 36 uses single quotes so the `$1` backref reaches perl unexpanded by the shell; `$$1` in the Makefile emits a literal `$1`.
- `perl` is present on `ubuntu-latest` (CI) and macOS, and `perl -i` with no suffix edits in place with no backup on both.

## Test plan

Run on macOS (BSD userland), the platform that was broken:

```
$ GOWORK=off make generate
… (full regeneration)
exit=0

$ git status --short
 M Makefile          # only the Makefile changed — every regenerated file is byte-identical

$ find . -name '*-e' -o -name '*.bak'
                     # no matches — zero backup litter
```

A byte-identical regeneration proves the `perl` transforms are behavior-equivalent to the previous `sed` commands.
