### PR TITLE
ci: include generator release notes in automated bump PR descriptions

### DIFF
--- a/.github/workflows/bump-generator.yml
+++ b/.github/workflows/bump-generator.yml
@@ -58,8 +58,24 @@ jobs:
           make install
           make generate
 
+      - name: Prepare PR body with release notes
+        id: body
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          notes=$(gh api "repos/webrpc/${GENERATOR}/releases/tags/${VERSION}" --jq '.body // ""' 2>/dev/null || true)
+          [ -z "$notes" ] && notes="_No GitHub release found for ${VERSION} when this PR was opened._"
+          {
+            echo "body<<EOF_PR_BODY"
+            echo "Automated bump of [\`webrpc/${GENERATOR}@${VERSION}\`](https://github.com/webrpc/${GENERATOR}/releases/tag/${VERSION})."
+            echo ""
+            printf '%s\n' "$notes"
+            echo "EOF_PR_BODY"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Commit and create pull request
-        uses: 0xsequence/actions/git-commit@v0.0.7
+        uses: 0xsequence/actions/git-commit@v0.10.0
         env:
           API_TOKEN_GITHUB: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -68,7 +84,7 @@ jobs:
           commit_message: "chore(deps): update webrpc/${{ env.GENERATOR }}@${{ env.VERSION }}"
           pr_create: "true"
           pr_title: "chore(deps): update webrpc/${{ env.GENERATOR }}@${{ env.VERSION }}"
-          pr_description: "Automated bump of `webrpc/${{ env.GENERATOR }}` to `${{ env.VERSION }}`."
+          pr_description: "${{ steps.body.outputs.body }}"
           pr_labels: "automated,dependencies"
 
   detect-poll:
@@ -153,8 +169,24 @@ jobs:
           make install
           make generate
 
+      - name: Prepare PR body with release notes
+        id: body
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          notes=$(gh api "repos/webrpc/${GENERATOR}/releases/tags/${VERSION}" --jq '.body // ""' 2>/dev/null || true)
+          [ -z "$notes" ] && notes="_No GitHub release found for ${VERSION} when this PR was opened._"
+          {
+            echo "body<<EOF_PR_BODY"
+            echo "Automated bump of [\`webrpc/${GENERATOR}@${VERSION}\`](https://github.com/webrpc/${GENERATOR}/releases/tag/${VERSION})."
+            echo ""
+            printf '%s\n' "$notes"
+            echo "EOF_PR_BODY"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Commit and create pull request
-        uses: 0xsequence/actions/git-commit@v0.0.7
+        uses: 0xsequence/actions/git-commit@v0.10.0
         env:
           API_TOKEN_GITHUB: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -163,5 +195,5 @@ jobs:
           commit_message: "chore(deps): update webrpc/${{ env.GENERATOR }}@${{ env.VERSION }}"
           pr_create: "true"
           pr_title: "chore(deps): update webrpc/${{ env.GENERATOR }}@${{ env.VERSION }}"
-          pr_description: "Automated bump of `webrpc/${{ env.GENERATOR }}` to `${{ env.VERSION }}`."
+          pr_description: "${{ steps.body.outputs.body }}"
           pr_labels: "automated,dependencies"


### PR DESCRIPTION
Automated generator bump PRs now include the generator's GitHub release notes as the PR description, instead of a static one-liner.

## Changes

- New `Prepare PR body with release notes` step in both jobs (`bump-dispatch` and `bump-poll`): fetches the release body for the bumped tag via `gh api`, with fallback text when a tag has no release.
- Bumps `0xsequence/actions/git-commit` `v0.0.7` → `v0.10.0`, which fixes JSON escaping of quotes, backslashes, and CRLF in `pr_description` (0xsequence/actions#199). Without that fix, real release notes (CRLF line endings) produced invalid JSON and PR creation failed.

## Testing

- Step simulated end-to-end with the real `gen-golang v0.32.5` release notes: output renders as clean markdown, heredoc delimiters safe.
- `v0.10.0` action verified to contain the escaping fix; old-vs-new payloads differentially tested for backwards compatibility (11 cases, bash + dash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)