### PR TITLE
chore: add go get instructions to release notes header

### DIFF
--- a/.github/.goreleaser.yml
+++ b/.github/.goreleaser.yml
@@ -48,6 +48,11 @@ checksum:
 
 release:
   replace_existing_artifacts: true
+  header: |
+    ## Go package
+    ```
+    go get github.com/webrpc/webrpc@v{{.Version}}
+    ```
   footer: |
     ## Docker
     ```


### PR DESCRIPTION
Adds a `release.header` block to `.goreleaser.yml` so each GitHub release starts with:

    ## Go package
    go get github.com/webrpc/webrpc@v{{.Version}}

Version is templated, matching the existing footer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)