### PR TITLE
chore: make goreleaser replace UI-written release notes

### DIFF
--- a/.github/.goreleaser.yml
+++ b/.github/.goreleaser.yml
@@ -48,6 +48,8 @@ checksum:
 
 release:
   replace_existing_artifacts: true
+  # Overwrite notes typed in the GitHub UI, so header/footer always apply.
+  mode: replace
   header: |
     ## Go package
     ```

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,20 @@
+# Config for GitHub's auto-generated release notes.
+# Used by the "Generate release notes" button and goreleaser's github-native changelog.
+# See https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
+
+changelog:
+  exclude:
+    authors:
+      - dependabot
+  categories:
+    - title: Features
+      labels:
+        - feature
+        - enhancement
+    - title: Bug fixes
+      labels:
+        - bug
+        - fix
+    - title: Other changes
+      labels:
+        - "*"


### PR DESCRIPTION
Follow-up to #494 — the `go get` header never showed up on releases created via the GitHub UI.

**Cause:** goreleaser v2 defaults to `release.mode: keep-existing`. Creating the release in the UI (which pushes the tag) means the release already exists when goreleaser runs, so it keeps the UI body and skips the header/footer.

**Fix:**
- `release.mode: replace` — goreleaser regenerates the body: header + changelog + footer.
- `.github/release.yml` — categorizes the changelog; respected both by the UI "Generate release notes" button and goreleaser's `github-native` changelog.

Anything typed manually into the UI release body will now be overwritten by goreleaser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)