### PR TITLE
fix(gen/golang): recover WebRPCError status through wrapped and joined errors

### DIFF
--- a/_examples/golang-basics/admin/admin.gen.go
+++ b/_examples/golang-basics/admin/admin.gen.go
@@ -432,8 +432,8 @@ func (s *adminService) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	case "application/json":
 		if s.OnRequest != nil {
 			if err := s.OnRequest(w, r); err != nil {
-				rpcErr, ok := err.(WebRPCError)
-				if !ok {
+				var rpcErr WebRPCError
+				if !errors.As(err, &rpcErr) {
 					rpcErr = ErrWebrpcEndpoint.WithCause(err)
 				}
 				s.sendErrorJSON(w, r, rpcErr)
@@ -454,8 +454,8 @@ func (s *adminService) serveAuthJSON(ctx context.Context, w http.ResponseWriter,
 	// Call service method implementation.
 	ret0, ret1, err := s.AdminServer.Auth(ctx)
 	if err != nil {
-		rpcErr, ok := err.(WebRPCError)
-		if !ok {
+		var rpcErr WebRPCError
+		if !errors.As(err, &rpcErr) {
 			rpcErr = ErrWebrpcEndpoint.WithCause(err)
 		}
 		s.sendErrorJSON(w, r, rpcErr)
@@ -483,8 +483,8 @@ func (s *adminService) serveStatusJSON(ctx context.Context, w http.ResponseWrite
 	// Call service method implementation.
 	ret0, err := s.AdminServer.Status(ctx)
 	if err != nil {
-		rpcErr, ok := err.(WebRPCError)
-		if !ok {
+		var rpcErr WebRPCError
+		if !errors.As(err, &rpcErr) {
 			rpcErr = ErrWebrpcEndpoint.WithCause(err)
 		}
 		s.sendErrorJSON(w, r, rpcErr)
@@ -511,8 +511,8 @@ func (s *adminService) serveVersionJSON(ctx context.Context, w http.ResponseWrit
 	// Call service method implementation.
 	ret0, err := s.AdminServer.Version(ctx)
 	if err != nil {
-		rpcErr, ok := err.(WebRPCError)
-		if !ok {
+		var rpcErr WebRPCError
+		if !errors.As(err, &rpcErr) {
 			rpcErr = ErrWebrpcEndpoint.WithCause(err)
 		}
 		s.sendErrorJSON(w, r, rpcErr)
@@ -563,8 +563,8 @@ func (s Server) Methods(opts *Options) []Method {
 }
 
 func RespondWithError(w http.ResponseWriter, err error) {
-	rpcErr, ok := err.(WebRPCError)
-	if !ok {
+	var rpcErr WebRPCError
+	if !errors.As(err, &rpcErr) {
 		rpcErr = ErrWebrpcEndpoint.WithCause(err)
 	}
 

--- a/_examples/golang-basics/example.gen.go
+++ b/_examples/golang-basics/example.gen.go
@@ -505,8 +505,8 @@ func (s *exampleService) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	case "application/json":
 		if s.OnRequest != nil {
 			if err := s.OnRequest(w, r); err != nil {
-				rpcErr, ok := err.(WebRPCError)
-				if !ok {
+				var rpcErr WebRPCError
+				if !errors.As(err, &rpcErr) {
 					rpcErr = ErrWebrpcEndpoint.WithCause(err)
 				}
 				s.sendErrorJSON(w, r, rpcErr)
@@ -527,8 +527,8 @@ func (s *exampleService) servePingJSON(ctx context.Context, w http.ResponseWrite
 	// Call service method implementation.
 	err := s.ExampleServer.Ping(ctx)
 	if err != nil {
-		rpcErr, ok := err.(WebRPCError)
-		if !ok {
+		var rpcErr WebRPCError
+		if !errors.As(err, &rpcErr) {
 			rpcErr = ErrWebrpcEndpoint.WithCause(err)
 		}
 		s.sendErrorJSON(w, r, rpcErr)
@@ -546,8 +546,8 @@ func (s *exampleService) serveStatusJSON(ctx context.Context, w http.ResponseWri
 	// Call service method implementation.
 	ret0, err := s.ExampleServer.Status(ctx)
 	if err != nil {
-		rpcErr, ok := err.(WebRPCError)
-		if !ok {
+		var rpcErr WebRPCError
+		if !errors.As(err, &rpcErr) {
 			rpcErr = ErrWebrpcEndpoint.WithCause(err)
 		}
 		s.sendErrorJSON(w, r, rpcErr)
@@ -574,8 +574,8 @@ func (s *exampleService) serveVersionJSON(ctx context.Context, w http.ResponseWr
 	// Call service method implementation.
 	ret0, err := s.ExampleServer.Version(ctx)
 	if err != nil {
-		rpcErr, ok := err.(WebRPCError)
-		if !ok {
+		var rpcErr WebRPCError
+		if !errors.As(err, &rpcErr) {
 			rpcErr = ErrWebrpcEndpoint.WithCause(err)
 		}
 		s.sendErrorJSON(w, r, rpcErr)
@@ -617,8 +617,8 @@ func (s *exampleService) serveFindUserJSON(ctx context.Context, w http.ResponseW
 	// Call service method implementation.
 	ret0, ret1, err := s.ExampleServer.FindUser(ctx, reqPayload.Arg0)
 	if err != nil {
-		rpcErr, ok := err.(WebRPCError)
-		if !ok {
+		var rpcErr WebRPCError
+		if !errors.As(err, &rpcErr) {
 			rpcErr = ErrWebrpcEndpoint.WithCause(err)
 		}
 		s.sendErrorJSON(w, r, rpcErr)
@@ -646,8 +646,8 @@ func (s *exampleService) serveGetIntentsJSON(ctx context.Context, w http.Respons
 	// Call service method implementation.
 	ret0, err := s.ExampleServer.GetIntents(ctx)
 	if err != nil {
-		rpcErr, ok := err.(WebRPCError)
-		if !ok {
+		var rpcErr WebRPCError
+		if !errors.As(err, &rpcErr) {
 			rpcErr = ErrWebrpcEndpoint.WithCause(err)
 		}
 		s.sendErrorJSON(w, r, rpcErr)
@@ -689,8 +689,8 @@ func (s *exampleService) serveCountIntentsJSON(ctx context.Context, w http.Respo
 	// Call service method implementation.
 	ret0, err := s.ExampleServer.CountIntents(ctx, reqPayload.Arg0)
 	if err != nil {
-		rpcErr, ok := err.(WebRPCError)
-		if !ok {
+		var rpcErr WebRPCError
+		if !errors.As(err, &rpcErr) {
 			rpcErr = ErrWebrpcEndpoint.WithCause(err)
 		}
 		s.sendErrorJSON(w, r, rpcErr)
@@ -741,8 +741,8 @@ func (s Server) Methods(opts *Options) []Method {
 }
 
 func RespondWithError(w http.ResponseWriter, err error) {
-	rpcErr, ok := err.(WebRPCError)
-	if !ok {
+	var rpcErr WebRPCError
+	if !errors.As(err, &rpcErr) {
 		rpcErr = ErrWebrpcEndpoint.WithCause(err)
 	}
 
@@ -774,8 +774,8 @@ func succinctHandler[I any, O any](method string, fn func(context.Context, I) (O
 
 		respPayload, err := fn(ctx, reqPayload)
 		if err != nil {
-			rpcErr, ok := err.(WebRPCError)
-			if !ok {
+			var rpcErr WebRPCError
+			if !errors.As(err, &rpcErr) {
 				rpcErr = ErrWebrpcEndpoint.WithCause(err)
 			}
 			sendError(w, r, rpcErr)

--- a/_examples/golang-basics/example_test.go
+++ b/_examples/golang-basics/example_test.go
@@ -70,6 +70,15 @@ func TestGetUser(t *testing.T) {
 	}
 
 	{
+		// A joined WebRPCError must keep its typed status, not degrade to a generic endpoint error.
+		resp, err := client.GetUserV2(context.Background(), GetUserRequest{UserID: 1234})
+		assert.Nil(t, resp)
+		var werr WebRPCError
+		assert.ErrorAs(t, err, &werr)
+		assert.Equal(t, ErrUserNotFound.Code, werr.Code)
+	}
+
+	{
 		name, user, err := client.FindUser(context.Background(), &SearchFilter{Q: "joe"})
 		assert.Equal(t, "joe", name)
 		assert.Equal(t, &User{ID: 123, Username: "joe"}, user)

--- a/_examples/golang-basics/internal/internal.gen.go
+++ b/_examples/golang-basics/internal/internal.gen.go
@@ -477,8 +477,8 @@ func (s *exampleService) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	case "application/json":
 		if s.OnRequest != nil {
 			if err := s.OnRequest(w, r); err != nil {
-				rpcErr, ok := err.(WebRPCError)
-				if !ok {
+				var rpcErr WebRPCError
+				if !errors.As(err, &rpcErr) {
 					rpcErr = ErrWebrpcEndpoint.WithCause(err)
 				}
 				s.sendErrorJSON(w, r, rpcErr)
@@ -499,8 +499,8 @@ func (s *exampleService) servePingJSON(ctx context.Context, w http.ResponseWrite
 	// Call service method implementation.
 	err := s.ExampleServer.Ping(ctx)
 	if err != nil {
-		rpcErr, ok := err.(WebRPCError)
-		if !ok {
+		var rpcErr WebRPCError
+		if !errors.As(err, &rpcErr) {
 			rpcErr = ErrWebrpcEndpoint.WithCause(err)
 		}
 		s.sendErrorJSON(w, r, rpcErr)
@@ -518,8 +518,8 @@ func (s *exampleService) serveStatusJSON(ctx context.Context, w http.ResponseWri
 	// Call service method implementation.
 	ret0, err := s.ExampleServer.Status(ctx)
 	if err != nil {
-		rpcErr, ok := err.(WebRPCError)
-		if !ok {
+		var rpcErr WebRPCError
+		if !errors.As(err, &rpcErr) {
 			rpcErr = ErrWebrpcEndpoint.WithCause(err)
 		}
 		s.sendErrorJSON(w, r, rpcErr)
@@ -546,8 +546,8 @@ func (s *exampleService) serveVersionJSON(ctx context.Context, w http.ResponseWr
 	// Call service method implementation.
 	ret0, err := s.ExampleServer.Version(ctx)
 	if err != nil {
-		rpcErr, ok := err.(WebRPCError)
-		if !ok {
+		var rpcErr WebRPCError
+		if !errors.As(err, &rpcErr) {
 			rpcErr = ErrWebrpcEndpoint.WithCause(err)
 		}
 		s.sendErrorJSON(w, r, rpcErr)
@@ -646,8 +646,8 @@ func (s *adminService) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	case "application/json":
 		if s.OnRequest != nil {
 			if err := s.OnRequest(w, r); err != nil {
-				rpcErr, ok := err.(WebRPCError)
-				if !ok {
+				var rpcErr WebRPCError
+				if !errors.As(err, &rpcErr) {
 					rpcErr = ErrWebrpcEndpoint.WithCause(err)
 				}
 				s.sendErrorJSON(w, r, rpcErr)
@@ -668,8 +668,8 @@ func (s *adminService) serveStatusJSON(ctx context.Context, w http.ResponseWrite
 	// Call service method implementation.
 	ret0, err := s.AdminServer.Status(ctx)
 	if err != nil {
-		rpcErr, ok := err.(WebRPCError)
-		if !ok {
+		var rpcErr WebRPCError
+		if !errors.As(err, &rpcErr) {
 			rpcErr = ErrWebrpcEndpoint.WithCause(err)
 		}
 		s.sendErrorJSON(w, r, rpcErr)
@@ -696,8 +696,8 @@ func (s *adminService) serveVersionJSON(ctx context.Context, w http.ResponseWrit
 	// Call service method implementation.
 	ret0, err := s.AdminServer.Version(ctx)
 	if err != nil {
-		rpcErr, ok := err.(WebRPCError)
-		if !ok {
+		var rpcErr WebRPCError
+		if !errors.As(err, &rpcErr) {
 			rpcErr = ErrWebrpcEndpoint.WithCause(err)
 		}
 		s.sendErrorJSON(w, r, rpcErr)
@@ -750,8 +750,8 @@ func (s Server) Methods(opts *Options) []Method {
 }
 
 func RespondWithError(w http.ResponseWriter, err error) {
-	rpcErr, ok := err.(WebRPCError)
-	if !ok {
+	var rpcErr WebRPCError
+	if !errors.As(err, &rpcErr) {
 		rpcErr = ErrWebrpcEndpoint.WithCause(err)
 	}
 

--- a/_examples/golang-basics/main.go
+++ b/_examples/golang-basics/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -129,6 +130,11 @@ func (s *ExampleServiceRPC) GetUserV2(ctx context.Context, req GetUserRequest) (
 	}
 	if req.UserID == 31337 {
 		return nil, ErrUserNotFound.WithCausef("unknown user id %d", req.UserID)
+	}
+	if req.UserID == 1234 {
+		// A WebRPCError joined with a second error. The transport must recover
+		// the typed status through the join, not degrade to a generic endpoint error.
+		return nil, errors.Join(ErrUserNotFound.WithCausef("unknown user id %d", req.UserID), errors.New("secondary failure"))
 	}
 
 	kind := Kind_ADMIN

--- a/_examples/golang-imports/api.gen.go
+++ b/_examples/golang-imports/api.gen.go
@@ -259,8 +259,8 @@ func (s *exampleAPIService) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	case "application/json":
 		if s.OnRequest != nil {
 			if err := s.OnRequest(w, r); err != nil {
-				rpcErr, ok := err.(WebRPCError)
-				if !ok {
+				var rpcErr WebRPCError
+				if !errors.As(err, &rpcErr) {
 					rpcErr = ErrWebrpcEndpoint.WithCause(err)
 				}
 				s.sendErrorJSON(w, r, rpcErr)
@@ -281,8 +281,8 @@ func (s *exampleAPIService) servePingJSON(ctx context.Context, w http.ResponseWr
 	// Call service method implementation.
 	err := s.ExampleAPIServer.Ping(ctx)
 	if err != nil {
-		rpcErr, ok := err.(WebRPCError)
-		if !ok {
+		var rpcErr WebRPCError
+		if !errors.As(err, &rpcErr) {
 			rpcErr = ErrWebrpcEndpoint.WithCause(err)
 		}
 		s.sendErrorJSON(w, r, rpcErr)
@@ -300,8 +300,8 @@ func (s *exampleAPIService) serveStatusJSON(ctx context.Context, w http.Response
 	// Call service method implementation.
 	ret0, err := s.ExampleAPIServer.Status(ctx)
 	if err != nil {
-		rpcErr, ok := err.(WebRPCError)
-		if !ok {
+		var rpcErr WebRPCError
+		if !errors.As(err, &rpcErr) {
 			rpcErr = ErrWebrpcEndpoint.WithCause(err)
 		}
 		s.sendErrorJSON(w, r, rpcErr)
@@ -328,8 +328,8 @@ func (s *exampleAPIService) serveGetUsersJSON(ctx context.Context, w http.Respon
 	// Call service method implementation.
 	ret0, ret1, err := s.ExampleAPIServer.GetUsers(ctx)
 	if err != nil {
-		rpcErr, ok := err.(WebRPCError)
-		if !ok {
+		var rpcErr WebRPCError
+		if !errors.As(err, &rpcErr) {
 			rpcErr = ErrWebrpcEndpoint.WithCause(err)
 		}
 		s.sendErrorJSON(w, r, rpcErr)
@@ -381,8 +381,8 @@ func (s Server) Methods(opts *Options) []Method {
 }
 
 func RespondWithError(w http.ResponseWriter, err error) {
-	rpcErr, ok := err.(WebRPCError)
-	if !ok {
+	var rpcErr WebRPCError
+	if !errors.As(err, &rpcErr) {
 		rpcErr = ErrWebrpcEndpoint.WithCause(err)
 	}
 

--- a/_examples/hello-webrpc/server/hello_api.gen.go
+++ b/_examples/hello-webrpc/server/hello_api.gen.go
@@ -194,8 +194,8 @@ func (s *exampleService) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	case "application/json":
 		if s.OnRequest != nil {
 			if err := s.OnRequest(w, r); err != nil {
-				rpcErr, ok := err.(WebRPCError)
-				if !ok {
+				var rpcErr WebRPCError
+				if !errors.As(err, &rpcErr) {
 					rpcErr = ErrWebrpcEndpoint.WithCause(err)
 				}
 				s.sendErrorJSON(w, r, rpcErr)
@@ -216,8 +216,8 @@ func (s *exampleService) servePingJSON(ctx context.Context, w http.ResponseWrite
 	// Call service method implementation.
 	ret0, err := s.ExampleServer.Ping(ctx)
 	if err != nil {
-		rpcErr, ok := err.(WebRPCError)
-		if !ok {
+		var rpcErr WebRPCError
+		if !errors.As(err, &rpcErr) {
 			rpcErr = ErrWebrpcEndpoint.WithCause(err)
 		}
 		s.sendErrorJSON(w, r, rpcErr)
@@ -259,8 +259,8 @@ func (s *exampleService) serveGetUserJSON(ctx context.Context, w http.ResponseWr
 	// Call service method implementation.
 	ret0, err := s.ExampleServer.GetUser(ctx, reqPayload.Arg0)
 	if err != nil {
-		rpcErr, ok := err.(WebRPCError)
-		if !ok {
+		var rpcErr WebRPCError
+		if !errors.As(err, &rpcErr) {
 			rpcErr = ErrWebrpcEndpoint.WithCause(err)
 		}
 		s.sendErrorJSON(w, r, rpcErr)
@@ -302,8 +302,8 @@ func (s *exampleService) serveFindUsersJSON(ctx context.Context, w http.Response
 	// Call service method implementation.
 	ret0, ret1, err := s.ExampleServer.FindUsers(ctx, reqPayload.Arg0)
 	if err != nil {
-		rpcErr, ok := err.(WebRPCError)
-		if !ok {
+		var rpcErr WebRPCError
+		if !errors.As(err, &rpcErr) {
 			rpcErr = ErrWebrpcEndpoint.WithCause(err)
 		}
 		s.sendErrorJSON(w, r, rpcErr)
@@ -355,8 +355,8 @@ func (s Server) Methods(opts *Options) []Method {
 }
 
 func RespondWithError(w http.ResponseWriter, err error) {
-	rpcErr, ok := err.(WebRPCError)
-	if !ok {
+	var rpcErr WebRPCError
+	if !errors.As(err, &rpcErr) {
 		rpcErr = ErrWebrpcEndpoint.WithCause(err)
 	}
 

--- a/_examples/webrpc-streaming/proto/chat.gen.go
+++ b/_examples/webrpc-streaming/proto/chat.gen.go
@@ -354,8 +354,8 @@ func (s *chatService) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	case "application/json":
 		if s.OnRequest != nil {
 			if err := s.OnRequest(w, r); err != nil {
-				rpcErr, ok := err.(WebRPCError)
-				if !ok {
+				var rpcErr WebRPCError
+				if !errors.As(err, &rpcErr) {
 					rpcErr = ErrWebrpcEndpoint.WithCause(err)
 				}
 				s.sendErrorJSON(w, r, rpcErr)
@@ -392,8 +392,8 @@ func (s *chatService) serveSendMessageJSON(ctx context.Context, w http.ResponseW
 	// Call service method implementation.
 	err = s.ChatServer.SendMessage(ctx, reqPayload.Arg0, reqPayload.Arg1)
 	if err != nil {
-		rpcErr, ok := err.(WebRPCError)
-		if !ok {
+		var rpcErr WebRPCError
+		if !errors.As(err, &rpcErr) {
 			rpcErr = ErrWebrpcEndpoint.WithCause(err)
 		}
 		s.sendErrorJSON(w, r, rpcErr)
@@ -453,8 +453,8 @@ func (s *chatService) serveSubscribeMessagesJSONStream(ctx context.Context, w ht
 	// Call service method implementation.
 	if err := s.ChatServer.SubscribeMessages(ctx, reqPayload.Arg0, reqPayload.Arg1, streamWriter); err != nil {
 		cancel()
-		rpcErr, ok := err.(WebRPCError)
-		if !ok {
+		var rpcErr WebRPCError
+		if !errors.As(err, &rpcErr) {
 			rpcErr = ErrWebrpcEndpoint.WithCause(err)
 		}
 		streamWriter.mu.Lock()
@@ -503,8 +503,8 @@ func (s Server) Methods(opts *Options) []Method {
 }
 
 func RespondWithError(w http.ResponseWriter, err error) {
-	rpcErr, ok := err.(WebRPCError)
-	if !ok {
+	var rpcErr WebRPCError
+	if !errors.As(err, &rpcErr) {
 		rpcErr = ErrWebrpcEndpoint.WithCause(err)
 	}
 

--- a/gen/golang/server.go.tmpl
+++ b/gen/golang/server.go.tmpl
@@ -107,8 +107,8 @@ func (s *{{$serviceName}}) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	case "application/json":
 		if s.OnRequest != nil {
 			if err := s.OnRequest(w, r); err != nil {
-				rpcErr, ok := err.(WebRPCError)
-				if !ok {
+				var rpcErr WebRPCError
+				if !errors.As(err, &rpcErr) {
 					rpcErr = ErrWebrpcEndpoint.WithCause(err)
 				}
 				s.sendErrorJSON(w, r, rpcErr)
@@ -151,8 +151,8 @@ func (s *{{$serviceName}}) serve{{firstLetterToUpper $method.Name}}JSON(ctx cont
 	// Call service method implementation.
 	{{range $i, $output := $method.Outputs}}ret{{$i}}, {{end}}err {{if or (eq (len $method.Inputs) 0) (gt (len $method.Outputs) 0)}}:{{end}}= s.{{$name}}Server.{{$method.Name}}(ctx{{range $i, $_ := $method.Inputs}}, reqPayload.Arg{{$i}}{{end}})
 	if err != nil {
-		rpcErr, ok := err.(WebRPCError)
-		if !ok {
+		var rpcErr WebRPCError
+		if !errors.As(err, &rpcErr) {
 			rpcErr = ErrWebrpcEndpoint.WithCause(err)
 		}
 		s.sendErrorJSON(w, r, rpcErr)
@@ -247,8 +247,8 @@ func (s *{{$serviceName}}) serve{{firstLetterToUpper $method.Name}}JSONStream(ct
 	// Call service method implementation.
 	if err {{if or (eq (len $method.Inputs) 0) (gt (len $method.Outputs) 0)}}:{{end}}= s.{{$name}}Server.{{$method.Name}}(ctx{{range $i, $_ := $method.Inputs}}, {{ if $method.Succinct }}reqPayload{{ else }}reqPayload.Arg{{$i}}{{ end }}{{end}}, streamWriter); err != nil {
 		cancel()
-		rpcErr, ok := err.(WebRPCError)
-		if !ok {
+		var rpcErr WebRPCError
+		if !errors.As(err, &rpcErr) {
 			rpcErr = ErrWebrpcEndpoint.WithCause(err)
 		}
 		streamWriter.mu.Lock()
@@ -306,8 +306,8 @@ func (s Server) Methods(opts *Options) []Method {
 }
 
 func RespondWithError(w http.ResponseWriter, err error) {
-	rpcErr, ok := err.(WebRPCError)
-	if !ok {
+	var rpcErr WebRPCError
+	if !errors.As(err, &rpcErr) {
 		rpcErr = ErrWebrpcEndpoint.WithCause(err)
 	}
 
@@ -340,8 +340,8 @@ func succinctHandler[I any, O any](method string, fn func(context.Context, I) (O
 
 		respPayload, err := fn(ctx, reqPayload)
 		if err != nil {
-			rpcErr, ok := err.(WebRPCError)
-			if !ok {
+			var rpcErr WebRPCError
+			if !errors.As(err, &rpcErr) {
 				rpcErr = ErrWebrpcEndpoint.WithCause(err)
 			}
 			sendError(w, r, rpcErr)

--- a/tests/server/server.gen.go
+++ b/tests/server/server.gen.go
@@ -296,8 +296,8 @@ func (s *testApiService) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	case "application/json":
 		if s.OnRequest != nil {
 			if err := s.OnRequest(w, r); err != nil {
-				rpcErr, ok := err.(WebRPCError)
-				if !ok {
+				var rpcErr WebRPCError
+				if !errors.As(err, &rpcErr) {
 					rpcErr = ErrWebrpcEndpoint.WithCause(err)
 				}
 				s.sendErrorJSON(w, r, rpcErr)
@@ -318,8 +318,8 @@ func (s *testApiService) serveGetEmptyJSON(ctx context.Context, w http.ResponseW
 	// Call service method implementation.
 	err := s.TestApiServer.GetEmpty(ctx)
 	if err != nil {
-		rpcErr, ok := err.(WebRPCError)
-		if !ok {
+		var rpcErr WebRPCError
+		if !errors.As(err, &rpcErr) {
 			rpcErr = ErrWebrpcEndpoint.WithCause(err)
 		}
 		s.sendErrorJSON(w, r, rpcErr)
@@ -337,8 +337,8 @@ func (s *testApiService) serveGetErrorJSON(ctx context.Context, w http.ResponseW
 	// Call service method implementation.
 	err := s.TestApiServer.GetError(ctx)
 	if err != nil {
-		rpcErr, ok := err.(WebRPCError)
-		if !ok {
+		var rpcErr WebRPCError
+		if !errors.As(err, &rpcErr) {
 			rpcErr = ErrWebrpcEndpoint.WithCause(err)
 		}
 		s.sendErrorJSON(w, r, rpcErr)
@@ -356,8 +356,8 @@ func (s *testApiService) serveGetOneJSON(ctx context.Context, w http.ResponseWri
 	// Call service method implementation.
 	ret0, err := s.TestApiServer.GetOne(ctx)
 	if err != nil {
-		rpcErr, ok := err.(WebRPCError)
-		if !ok {
+		var rpcErr WebRPCError
+		if !errors.As(err, &rpcErr) {
 			rpcErr = ErrWebrpcEndpoint.WithCause(err)
 		}
 		s.sendErrorJSON(w, r, rpcErr)
@@ -399,8 +399,8 @@ func (s *testApiService) serveSendOneJSON(ctx context.Context, w http.ResponseWr
 	// Call service method implementation.
 	err = s.TestApiServer.SendOne(ctx, reqPayload.Arg0)
 	if err != nil {
-		rpcErr, ok := err.(WebRPCError)
-		if !ok {
+		var rpcErr WebRPCError
+		if !errors.As(err, &rpcErr) {
 			rpcErr = ErrWebrpcEndpoint.WithCause(err)
 		}
 		s.sendErrorJSON(w, r, rpcErr)
@@ -418,8 +418,8 @@ func (s *testApiService) serveGetMultiJSON(ctx context.Context, w http.ResponseW
 	// Call service method implementation.
 	ret0, ret1, ret2, err := s.TestApiServer.GetMulti(ctx)
 	if err != nil {
-		rpcErr, ok := err.(WebRPCError)
-		if !ok {
+		var rpcErr WebRPCError
+		if !errors.As(err, &rpcErr) {
 			rpcErr = ErrWebrpcEndpoint.WithCause(err)
 		}
 		s.sendErrorJSON(w, r, rpcErr)
@@ -465,8 +465,8 @@ func (s *testApiService) serveSendMultiJSON(ctx context.Context, w http.Response
 	// Call service method implementation.
 	err = s.TestApiServer.SendMulti(ctx, reqPayload.Arg0, reqPayload.Arg1, reqPayload.Arg2)
 	if err != nil {
-		rpcErr, ok := err.(WebRPCError)
-		if !ok {
+		var rpcErr WebRPCError
+		if !errors.As(err, &rpcErr) {
 			rpcErr = ErrWebrpcEndpoint.WithCause(err)
 		}
 		s.sendErrorJSON(w, r, rpcErr)
@@ -484,8 +484,8 @@ func (s *testApiService) serveGetComplexJSON(ctx context.Context, w http.Respons
 	// Call service method implementation.
 	ret0, err := s.TestApiServer.GetComplex(ctx)
 	if err != nil {
-		rpcErr, ok := err.(WebRPCError)
-		if !ok {
+		var rpcErr WebRPCError
+		if !errors.As(err, &rpcErr) {
 			rpcErr = ErrWebrpcEndpoint.WithCause(err)
 		}
 		s.sendErrorJSON(w, r, rpcErr)
@@ -527,8 +527,8 @@ func (s *testApiService) serveSendComplexJSON(ctx context.Context, w http.Respon
 	// Call service method implementation.
 	err = s.TestApiServer.SendComplex(ctx, reqPayload.Arg0)
 	if err != nil {
-		rpcErr, ok := err.(WebRPCError)
-		if !ok {
+		var rpcErr WebRPCError
+		if !errors.As(err, &rpcErr) {
 			rpcErr = ErrWebrpcEndpoint.WithCause(err)
 		}
 		s.sendErrorJSON(w, r, rpcErr)
@@ -546,8 +546,8 @@ func (s *testApiService) serveGetEnumListJSON(ctx context.Context, w http.Respon
 	// Call service method implementation.
 	ret0, err := s.TestApiServer.GetEnumList(ctx)
 	if err != nil {
-		rpcErr, ok := err.(WebRPCError)
-		if !ok {
+		var rpcErr WebRPCError
+		if !errors.As(err, &rpcErr) {
 			rpcErr = ErrWebrpcEndpoint.WithCause(err)
 		}
 		s.sendErrorJSON(w, r, rpcErr)
@@ -574,8 +574,8 @@ func (s *testApiService) serveGetEnumMapJSON(ctx context.Context, w http.Respons
 	// Call service method implementation.
 	ret0, err := s.TestApiServer.GetEnumMap(ctx)
 	if err != nil {
-		rpcErr, ok := err.(WebRPCError)
-		if !ok {
+		var rpcErr WebRPCError
+		if !errors.As(err, &rpcErr) {
 			rpcErr = ErrWebrpcEndpoint.WithCause(err)
 		}
 		s.sendErrorJSON(w, r, rpcErr)
@@ -617,8 +617,8 @@ func (s *testApiService) serveGetSchemaErrorJSON(ctx context.Context, w http.Res
 	// Call service method implementation.
 	err = s.TestApiServer.GetSchemaError(ctx, reqPayload.Arg0)
 	if err != nil {
-		rpcErr, ok := err.(WebRPCError)
-		if !ok {
+		var rpcErr WebRPCError
+		if !errors.As(err, &rpcErr) {
 			rpcErr = ErrWebrpcEndpoint.WithCause(err)
 		}
 		s.sendErrorJSON(w, r, rpcErr)
@@ -660,8 +660,8 @@ func (s Server) Methods(opts *Options) []Method {
 }
 
 func RespondWithError(w http.ResponseWriter, err error) {
-	rpcErr, ok := err.(WebRPCError)
-	if !ok {
+	var rpcErr WebRPCError
+	if !errors.As(err, &rpcErr) {
 		rpcErr = ErrWebrpcEndpoint.WithCause(err)
 	}
 


### PR DESCRIPTION
## What

The generated Go server maps an error to its HTTP status with a direct `err.(WebRPCError)` type assertion. That assertion fails the moment a handler wraps or joins a `WebRPCError`:

- `fmt.Errorf("...: %w", myErr)`
- `errors.Join(myErr, other)` — e.g. a `defer tx.Rollback(ctx, &err)` that joins a rollback failure onto the returned error

When it fails, the response degrades to the generic `ErrWebrpcEndpoint` and serves the wrong HTTP status — a typed 4xx becomes a generic endpoint error.

This switches the five assertion sites in `gen/golang/server.go.tmpl` to `errors.As`, which walks the whole error tree — including `Unwrap() []error` (joins) since Go 1.20 — and recovers the `WebRPCError` through wrapping and joining.

## Does this need to be opt-in? No.

- `errors` is already imported by the generated code — no new import, no dependency.
- `errors.As` exists since Go 1.13 (tree/join walking since 1.20), well below the supported range (`go.mod` is `go 1.23`). It compiles for every supported consumer, so it ships safely as the default.
- `errors.AsType[WebRPCError](err)` (Go 1.26) reads nicer, but would force every consumer onto Go 1.26 — above the current range. Revisit if the minimum Go moves to 1.26.

## Behavior change (call-out)

An error that wraps or joins a `WebRPCError` now surfaces that error's real status instead of the generic endpoint error. This is the intended fix and is almost always more correct, but it is an observable change for any caller that relied on a wrap to force a generic error.

## Testing

- `make -C _examples/golang-basics generate test` — green. Added a case: a handler returning `errors.Join(ErrUserNotFound.WithCausef(...), ...)` must keep its typed status (404), not degrade to a generic 400.
- Verified it fails on the pre-fix template (`expected: 1000, actual: 0` — the `UserNotFound` code degrades to the generic endpoint code `0`) and passes after.

## Notes

- Supersedes `webrpc/gen-golang#143`, which fixed the same bug in the now-deprecated standalone repo. This targets the monorepo `gen/golang/` directly.
- `_examples/golang-imports` is left untouched: its committed output regenerates through a separate/older path and is unrelated to this change.
