### PR TITLE
feature: git branch and commit hash versioning for local generators

### DIFF
--- a/gen/template_source.go
+++ b/gen/template_source.go
@@ -6,6 +6,7 @@ import (
 	"hash/fnv"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -81,6 +82,7 @@ func (s *TemplateSource) loadTemplates() (*template.Template, error) {
 		}
 		s.TmplDir = s.target
 		s.TmplVersion = s.target
+		s.inferLocalTemplateVersion()
 		return tmpl, nil
 	}
 
@@ -92,6 +94,49 @@ func (s *TemplateSource) loadTemplates() (*template.Template, error) {
 		return nil, fmt.Errorf("failed to load templates from %s: %w", s.target, err)
 	}
 	return tmpl, nil
+}
+
+// inferLocalTemplateVersion attempts to extract a git branch and commit slug from the TmplDir
+// of a TemplateSource if its IsLocal flag is set and appends it to its TmplVersion.
+// If the local directory is not under git control or some other problem happens,
+// TmplVersion will be unchanged.
+func (s *TemplateSource) inferLocalTemplateVersion() {
+	if !s.IsLocal {
+		return
+	}
+
+	var branch string
+	{
+		cmd := exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD")
+		cmd.Dir = s.TmplDir
+		raw, err := cmd.Output()
+		if err != nil {
+			return
+		}
+		branch = strings.TrimSpace(string(raw))
+	}
+
+	var slug string
+	{
+		cmd := exec.Command("git", "rev-parse", "--short", "HEAD")
+		cmd.Dir = s.TmplDir
+		raw, err := cmd.Output()
+		if err != nil {
+			return
+		}
+		slug = strings.TrimSpace(string(raw))
+	}
+
+	sb := strings.Builder{}
+	sb.WriteString(s.TmplVersion)
+	// this '@' separator is essential for parseWebrpcGenVersions to work properly
+	sb.WriteRune('@')
+	sb.WriteString(branch)
+	// ':' is chosen to separate branch and commit slug because it is deemed illegal
+	// anywhere in refnames according to git-check-ref-format documentation.
+	sb.WriteRune(':')
+	sb.WriteString(slug)
+	s.TmplVersion = sb.String()
 }
 
 func (s *TemplateSource) loadRemote() (*template.Template, error) {


### PR DESCRIPTION
When using local directories as template repositories, the version of the generator in the webrpc header always shows as "unknown" for me. This patch uses git to extract the current branch and most recent abbreviated commit hash instead (as `branch:commit`). It should not have any effect unless (a) the `TemplateSource` is a local directory that (b) is a valid git repository and (c) local git tooling is able to properly use `git-rev-parse` to extract the desired information.

I apologize for the fact that `make-generate/run/run` seems to be failing. Both `make generate` and `make test` complete with no errors locally.