### PR TITLE
fix(gen/openapi): don't crash or emit invalid paths on a zero-service schema

### DIFF
--- a/gen/openapi/main.go.tmpl
+++ b/gen/openapi/main.go.tmpl
@@ -2,7 +2,11 @@
 
 {{- /* Options with default values. */ -}}
 {{- $opts := dict -}}
-{{- set $opts "title" (default .Opts.title (print (index .Services 0).Name " API")) -}}
+{{- if .Services -}}
+  {{- set $opts "title" (default .Opts.title (print (index .Services 0).Name " API")) -}}
+{{- else -}}
+  {{- set $opts "title" (default .Opts.title "API") -}}
+{{- end -}}
 {{- set $opts "apiVersion" (default .Opts.apiVersion "") -}}
 {{- set $opts "serverUrl" (default .Opts.serverUrl "") -}}
 {{- set $opts "serverDescription" (default .Opts.serverDescription "") -}}
@@ -147,6 +151,7 @@ components:
     {{- end -}}
     {{- end}}
 
+{{- if .Services }}
 paths:
 {{- range $_, $service := .Services -}}
   {{- range $_, $method := .Methods}}
@@ -302,5 +307,8 @@ paths:
                 {{- end -}}
                 {{- end }}
   {{- end -}}
+{{- end -}}
+{{- else }}
+paths: {}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
## Summary
- A RIDL schema with no `service` (struct-catalog-only, e.g. a shared data-model package with no RPC methods) crashes `gen-openapi` with `reflect: slice index out of range` — the default `title` unconditionally does `(index .Services 0).Name`.
- Separately, when `.Services` is empty, the `paths:` key is emitted with no value at all (`paths:` followed by nothing), which is invalid per the OpenAPI 3.0 spec — the Paths Object must be an object, even when empty (`paths: {}`).
- Fix: guard both — fall back to title `"API"` when there are no services, and emit `paths: {}` instead of a bare `paths:` key.

## Test plan
- [x] Generated OpenAPI from a zero-service RIDL schema (struct-only) — previously crashed, now succeeds with `title: 'API'` and `paths: {}`
- [x] Output validated with `openapi-spec-validator` (strict OpenAPI 3.0 schema check) — passes
- [x] Existing schemas with services unaffected (title still derives from `Services[0].Name`, `paths` still lists every method as before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>